### PR TITLE
Implemented visitPropertyUsingCustomHandler().

### DIFF
--- a/Serializer/GenericDeserializationVisitor.php
+++ b/Serializer/GenericDeserializationVisitor.php
@@ -195,7 +195,26 @@ abstract class GenericDeserializationVisitor extends AbstractDeserializationVisi
 
     public function visitPropertyUsingCustomHandler(PropertyMetadata $metadata, $object)
     {
-        // TODO
+        $name = $this->namingStrategy->translateName($metadata);
+        $visited = false;
+
+        if (!isset($object[$name])) {
+            return false;
+        }
+
+        if (!$metadata->type) {
+            throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->reflection->getDeclaringClass()->getName(), $metadata->name));
+        }
+
+        foreach ($this->customHandlers as $handler) {
+            $v = $handler->deserialize($this, $object[$name], $metadata->type, $visited);
+
+            if ($visited) {
+                $metadata->reflection->setValue($this->currentObject, $v);
+                return true;
+            }
+        }
+
         return false;
     }
 


### PR DESCRIPTION
I've implemented missing visitPropertyUsingCustomHandler() method. It works, but in my case it was only used because visitUsingCustomHandler() was not called because of other error.

Now I'm not sure if there is any use case when visitPropertyUsingCustomHandler() will be called. Is there any special case when custom handler won't be called in visitUsingCustomHandler()? If not, then visitPropertyUsingCustomHandler() is redundant.
