### PR TITLE
[Configuration] Sync with upstream symfony2.1

### DIFF
--- a/DependencyInjection/Factory/ArrayCollectionFactory.php
+++ b/DependencyInjection/Factory/ArrayCollectionFactory.php
@@ -22,7 +22,6 @@ class ArrayCollectionFactory implements HandlerFactoryInterface
     {
         $builder
             ->addDefaultsIfNotSet()
-            ->defaultValue(array())
         ;
     }
 

--- a/DependencyInjection/Factory/ConstraintViolationFactory.php
+++ b/DependencyInjection/Factory/ConstraintViolationFactory.php
@@ -22,7 +22,6 @@ class ConstraintViolationFactory implements HandlerFactoryInterface
     {
         $builder
             ->addDefaultsIfNotSet()
-            ->defaultValue(array())
         ;
     }
 

--- a/DependencyInjection/Factory/DoctrineProxyFactory.php
+++ b/DependencyInjection/Factory/DoctrineProxyFactory.php
@@ -22,7 +22,6 @@ class DoctrineProxyFactory implements HandlerFactoryInterface
     {
         $builder
             ->addDefaultsIfNotSet()
-            ->defaultValue(array())
         ;
     }
 

--- a/DependencyInjection/Factory/FormErrorFactory.php
+++ b/DependencyInjection/Factory/FormErrorFactory.php
@@ -22,7 +22,6 @@ class FormErrorFactory implements HandlerFactoryInterface
     {
         $builder
             ->addDefaultsIfNotSet()
-            ->defaultValue(array())
         ;
     }
 


### PR DESCRIPTION
Removed redundant (and as of late erroneous) configuration default values, as mandated by symfony/symfony#3365, fixes #83.

@vicb Please confirm this is correct.
