### PR TITLE
Use array keys as xml tag

### DIFF
--- a/Serializer/XmlSerializationVisitor.php
+++ b/Serializer/XmlSerializationVisitor.php
@@ -111,10 +111,21 @@ class XmlSerializationVisitor extends AbstractSerializationVisitor
         }
 
         $entryName = (null !== $this->currentMetadata && null !== $this->currentMetadata->xmlEntryName) ? $this->currentMetadata->xmlEntryName : 'entry';
+        $entryNameOrig = $entryName;
         $keyAttributeName = (null !== $this->currentMetadata && null !== $this->currentMetadata->xmlKeyAttribute) ? $this->currentMetadata->xmlKeyAttribute : null;
 
         foreach ($data as $k => $v) {
+            if ($entryName==='entry' && is_string($k)) {
+                $entryName = $k;
+            }
+
             $entryNode = $this->document->createElement($entryName);
+
+            // We reset the entryName
+            if ($entryName !== $entryNameOrig) {
+                $entryName = $entryNameOrig;
+            }
+
             $this->currentNode->appendChild($entryNode);
             $this->setCurrentNode($entryNode);
 

--- a/Tests/Serializer/XmlSerializationTest.php
+++ b/Tests/Serializer/XmlSerializationTest.php
@@ -63,6 +63,22 @@ class XmlSerializationTest extends BaseSerializationTest
     {
         return 'xml';
     }
+
+    public function testAssociatedArray()
+    {
+        $data = array(
+            'foo' => 'bar',
+            'bar' => array(
+                'faz' => 'foo',
+                'far' => 1,
+                'boo' => array(
+                    'baz' => 'far',
+                ),
+                'raf',
+            )
+        );
+        $this->assertEquals($this->getContent('associated_array'), $this->serialize($data));
+    }
 }
 
 class ExternalEntityTest

--- a/Tests/Serializer/xml/associated_array.xml
+++ b/Tests/Serializer/xml/associated_array.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <foo><![CDATA[bar]]></foo>
+  <bar>
+    <faz><![CDATA[foo]]></faz>
+    <far>1</far>
+    <boo>
+      <baz><![CDATA[far]]></baz>
+    </boo>
+    <entry><![CDATA[raf]]></entry>
+  </bar>
+</result>


### PR DESCRIPTION
I've written a small patch to correct this behavior and its according test.

(by the way, JMSSerializerExtensionTest::testLoad didn't pass in revision 27fbaafc4dcfa7dae2160b4efde5f8543e2bc3f4)
