### PR TITLE
Add the Groups feature

### DIFF
--- a/Resources/doc/reference/annotations.rst
+++ b/Resources/doc/reference/annotations.rst
@@ -46,6 +46,18 @@ property was available. If a later version is serialized, then this property is
 excluded automatically. The version must be in a format that is understood by
 PHP's ``version_compare`` function.
 
+@Groups
+-------
+
+This annotation can be defined on a property to specifiy if this porperty should 
+be serialized, if any group is specified with the 
+``$serializer->setGroups(array("Foo"))`` method. Both values always have to be 
+an array.
+
+.. code-block :: php
+
+  /** @Groups({"Foo","Bar"}) */
+
 @AccessType
 ~~~~~~~~~~~
 This annotation can be defined on a property, or a class to specify in which way

--- a/Resources/doc/reference/xml_reference.rst
+++ b/Resources/doc/reference/xml_reference.rst
@@ -21,6 +21,7 @@ XML Reference
                       accessor-setter="setSomeProperty"
                       inline="true"
                       read-only="true"
+                      groups="foo,bar"
             >
                 <!-- You can also specify the type as element which is necessary if
                      your type contains "<" or ">" characters. -->

--- a/Resources/doc/reference/yml_reference.rst
+++ b/Resources/doc/reference/yml_reference.rst
@@ -19,6 +19,7 @@ YAML Reference
                 serialized_name: foo
                 since_version: 1.0
                 until_version: 1.1
+                groups: [foo, bar]
                 xml_attribute: true
                 inline: true
                 read_only: true


### PR DESCRIPTION
See #60

It adds `@Serializer\Group"

Annotate your properties with

```
* @Serializer\Group({"Bar","foo"})
```

then do

```
$serializer->setGroups(array("foo","zero"));
```

and if any matches, the property will be serialized. If none matches or there is no group tag, then it won't be serialized.

2 Things:
- Maybe we should use `Groups` instead of `Group`
- I didn't use `@Expose(groups={"user"})` which would maybe be better, since then we could use it also in Exclude. Now it's basically only usable as Expose.

If someone can give me a hint where I have to look for the 2nd point in the code, I could maybe change that.
