### PR TITLE
Added fix for nested element with attribute and value

### DIFF
--- a/Serializer/XmlSerializationVisitor.php
+++ b/Serializer/XmlSerializationVisitor.php
@@ -203,6 +203,8 @@ class XmlSerializationVisitor extends AbstractSerializationVisitor
                 $this->currentNode->appendChild($element);
             }
         }
+
+        $this->hasValue = false;
     }
 
     public function endVisitingObject(ClassMetadata $metadata, $data, $type)

--- a/Tests/Fixtures/Person.php
+++ b/Tests/Fixtures/Person.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace JMS\SerializerBundle\Tests\Fixtures;
+
+use JMS\SerializerBundle\Annotation\XmlAttribute;
+use JMS\SerializerBundle\Annotation\XmlValue;
+use JMS\SerializerBundle\Annotation\XmlRoot;
+use JMS\SerializerBundle\Annotation\Type;
+
+/**
+ * @XmlRoot("child")
+ */
+class Person
+{
+    /**
+     * @Type("string")
+     * @XmlValue
+     */
+    public $name;
+
+    /**
+     * @Type("integer")
+     * @XmlAttribute
+     */
+    public $age;
+}

--- a/Tests/Fixtures/PersonCollection.php
+++ b/Tests/Fixtures/PersonCollection.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace JMS\SerializerBundle\Tests\Fixtures;
+
+use JMS\SerializerBundle\Annotation\XmlRoot;
+use JMS\SerializerBundle\Annotation\XmlList;
+use Doctrine\Common\Collections\ArrayCollection;
+use JMS\SerializerBundle\Annotation\Type;
+
+/**
+ * @XmlRoot("person_collection")
+ */
+class PersonCollection
+{
+    /**
+     * @Type("ArrayCollection<JMS\SerializerBundle\Tests\Fixtures\Person>")
+     * @XmlList(entry = "person", inline = true)
+     */
+    public $persons;
+
+    /**
+     * @Type("string")
+     */
+    public $location;
+
+    public function __construct()
+    {
+        $this->persons = new ArrayCollection;
+    }
+}

--- a/Tests/Fixtures/PersonLocation.php
+++ b/Tests/Fixtures/PersonLocation.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace JMS\SerializerBundle\Tests\Fixtures;
+
+use JMS\SerializerBundle\Annotation\XmlRoot;
+use JMS\SerializerBundle\Annotation\Type;
+
+/**
+ * @XmlRoot("person_location")
+ */
+class PersonLocation
+{
+    /**
+     * @Type("JMS\SerializerBundle\Tests\Fixtures\Person")
+     */
+    public $person;
+
+    /**
+     * @Type("string")
+     */
+    public $location;
+}

--- a/Tests/Serializer/XmlSerializationTest.php
+++ b/Tests/Serializer/XmlSerializationTest.php
@@ -22,6 +22,9 @@ use JMS\SerializerBundle\Tests\Fixtures\InvalidUsageOfXmlValue;
 use JMS\SerializerBundle\Exception\InvalidArgumentException;
 use JMS\SerializerBundle\Annotation\Type;
 use JMS\SerializerBundle\Annotation\XmlValue;
+use JMS\SerializerBundle\Tests\Fixtures\PersonCollection;
+use JMS\SerializerBundle\Tests\Fixtures\PersonLocation;
+use JMS\SerializerBundle\Tests\Fixtures\Person;
 
 class XmlSerializationTest extends BaseSerializationTest
 {
@@ -32,6 +35,30 @@ class XmlSerializationTest extends BaseSerializationTest
     {
         $obj = new InvalidUsageOfXmlValue();
         $this->serialize($obj);
+    }
+
+    public function testPropertyIsObjectWithAttributeAndValue()
+    {
+        $personCollection = new PersonLocation;
+        $person = new Person;
+        $person->name = 'Matthias Noback';
+        $person->age = 28;
+        $personCollection->person = $person;
+        $personCollection->location = 'The Netherlands';
+
+        $this->assertEquals($this->getContent('person_location'), $this->serialize($personCollection));
+    }
+
+    public function testPropertyIsCollectionOfObjectsWithAttributeAndValue()
+    {
+        $personCollection = new PersonCollection;
+        $person = new Person;
+        $person->name = 'Matthias Noback';
+        $person->age = 28;
+        $personCollection->persons->add($person);
+        $personCollection->location = 'The Netherlands';
+
+        $this->assertEquals($this->getContent('person_collection'), $this->serialize($personCollection));
     }
 
     public function testExternalEntitiesAreDisabledByDefault()

--- a/Tests/Serializer/xml/person_collection.xml
+++ b/Tests/Serializer/xml/person_collection.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person_collection>
+  <person age="28"><![CDATA[Matthias Noback]]></person>
+  <location><![CDATA[The Netherlands]]></location>
+</person_collection>

--- a/Tests/Serializer/xml/person_location.xml
+++ b/Tests/Serializer/xml/person_location.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person_location>
+  <person age="28"><![CDATA[Matthias Noback]]></person>
+  <location><![CDATA[The Netherlands]]></location>
+</person_location>


### PR DESCRIPTION
Hi Johannes,

First of all: thank you for sharing this beautiful bundle!

I fixed an issue with the hasValue property of the XmlSerializationVisitor. The visitor remembers the use of  @XmlValue even when it is already outside the element it applies to. So when trying to create XML like

```
<person_collection>
  <person age="28">Matthias Noback</person>
  <location>The Netherlands</location>
</person_collection>
```

It fails on the "location" property, saying:

```
RuntimeException: If you make use of @XmlValue, all other properties in the class must have the @XmlAttribute annotation. Invalid usage detected in class JMS\SerializerBundle\Tests\Fixtures\PersonCollection.
```

It is a small fix (just reset the $hasValue property to false) for which I've added some tests. The existing tests don't fail with this fix in place.

Could you take a look at this please?
