### PR TITLE
Added an upper bound on the composer constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,10 @@
     "autoload": {
         "psr-0": { "JMS\\SerializerBundle": "" }
     },
-    "target-dir": "JMS/SerializerBundle"
+    "target-dir": "JMS/SerializerBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
Releasing a version with an unbound constraint implies that you know that any future version of Metadata (including major ones) will stay BC.
Using the master branch of metadata will still be possible once schmittjoh/metadata#8 is merged too
