### PR TITLE
Handle lowerCamelCase naming strategy

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -57,6 +57,7 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('id')->cannotBeEmpty()->end()
                     ->scalarNode('separator')->defaultValue('_')->end()
                     ->booleanNode('lower_case')->defaultTrue()->end()
+                    ->booleanNode('lower_camel_case')->defaultFalse()->end()
                     ->booleanNode('enable_cache')->defaultTrue()->end()
                 ->end()
             ->end()

--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -63,6 +63,7 @@ class JMSSerializerExtension extends Extension
             ->getDefinition('jms_serializer.camel_case_naming_strategy')
             ->addArgument($config['property_naming']['separator'])
             ->addArgument($config['property_naming']['lower_case'])
+            ->addArgument($config['property_naming']['lower_camel_case'])
         ;
         if ($config['property_naming']['enable_cache']) {
             $container

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -26,9 +26,18 @@ values:
                 form_error: true
                 constraint_violation: true
     
+            # To use lowerCamelCase set property_naming configuration like this
+            # separator: ""
+            # lower_case: false
+            # lower_camel_case: true
+            # To use UpperCamelCase set property_naming configuration like this
+            # separator: ""
+            # lower_case: false
+            # lower_camel_case: false
             property_naming:
                 separator:  _
                 lower_case: true
+                lower_camel_case: false
     
             metadata:
                 cache: file
@@ -70,7 +79,8 @@ values:
             
             <property-naming
                 seperator="_"
-                lower-case="true" />
+                lower-case="true"
+                lower-camel-case="false" />
                 
             <metadata
                 cache="file"

--- a/Serializer/Naming/CamelCaseNamingStrategy.php
+++ b/Serializer/Naming/CamelCaseNamingStrategy.php
@@ -29,11 +29,13 @@ class CamelCaseNamingStrategy implements PropertyNamingStrategyInterface
 {
     private $separator;
     private $lowerCase;
+    private $lowerCamelCase;
 
-    public function __construct($separator = '_', $lowerCase = true)
+    public function __construct($separator = '_', $lowerCase = true, $lowerCamelCase = false)
     {
         $this->separator = $separator;
         $this->lowerCase = $lowerCase;
+        $this->lowerCamelCase = $lowerCamelCase;
     }
 
     /**
@@ -49,6 +51,10 @@ class CamelCaseNamingStrategy implements PropertyNamingStrategyInterface
             return strtolower($name);
         }
 
+        if ($this->lowerCamelCase) {
+            return lcfirst($name);
+        }
+        
         return ucfirst($name);
     }
 }

--- a/Tests/Serializer/Naming/CamelCaseNamingStrategyTest.php
+++ b/Tests/Serializer/Naming/CamelCaseNamingStrategyTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace JMS\SerializerBundle\Tests\Serializer\Naming;
+
+use JMS\SerializerBundle\Metadata\PropertyMetadata;
+use JMS\SerializerBundle\Metadata\ClassMetadata;
+use JMS\SerializerBundle\Serializer\Naming\CamelCaseNamingStrategy;
+
+class CamelCaseNamingStrategyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaultCamelCaseNamingStrategy()
+    {
+        $camelCaseNamingStrategy = new CamelCaseNamingStrategy();
+
+        $metadata = new ClassMetadata('JMS\SerializerBundle\Tests\Serializer\Naming\camelCasePropertyMetadata');
+        $metadata->addPropertyMetadata(new PropertyMetadata('JMS\SerializerBundle\Tests\Serializer\Naming\camelCasePropertyMetadata', 'camelCaseProperty'));
+
+        $translatedPropertyName = $camelCaseNamingStrategy->translateName($metadata->propertyMetadata['camelCaseProperty']);
+
+        $this->assertEquals($translatedPropertyName, 'camel_case_property');
+    }
+
+    public function testLowerCaseNamingStrategy()
+    {
+        $separator = '';
+        $lowerCase = true;
+        $lowerCamelCase = true;
+
+        $camelCaseNamingStrategy = new CamelCaseNamingStrategy($separator, $lowerCase, $lowerCamelCase);
+
+        $metadata = new ClassMetadata('JMS\SerializerBundle\Tests\Serializer\Naming\camelCasePropertyMetadata');
+        $metadata->addPropertyMetadata(new PropertyMetadata('JMS\SerializerBundle\Tests\Serializer\Naming\camelCasePropertyMetadata', 'camelCaseProperty'));
+
+        $translatedPropertyName = $camelCaseNamingStrategy->translateName($metadata->propertyMetadata['camelCaseProperty']);
+
+        $this->assertEquals($translatedPropertyName, 'camelcaseproperty');
+    }
+
+    public function testLowerCamelCaseNamingStrategy()
+    {
+        $separator = '';
+        $lowerCase = false;
+        $lowerCamelCase = true;
+
+        $camelCaseNamingStrategy = new CamelCaseNamingStrategy($separator, $lowerCase, $lowerCamelCase);
+
+        $metadata = new ClassMetadata('JMS\SerializerBundle\Tests\Serializer\Naming\camelCasePropertyMetadata');
+        $metadata->addPropertyMetadata(new PropertyMetadata('JMS\SerializerBundle\Tests\Serializer\Naming\camelCasePropertyMetadata', 'camelCaseProperty'));
+
+        $translatedPropertyName = $camelCaseNamingStrategy->translateName($metadata->propertyMetadata['camelCaseProperty']);
+
+        $this->assertEquals($translatedPropertyName, 'camelCaseProperty');
+    }
+
+    public function testUpperCamelCaseNamingStrategy()
+    {
+        $separator = '';
+        $lowerCase = false;
+        $lowerCamelCase = false;
+
+        $camelCaseNamingStrategy = new CamelCaseNamingStrategy($separator, $lowerCase, $lowerCamelCase);
+
+        $metadata = new ClassMetadata('JMS\SerializerBundle\Tests\Serializer\Naming\camelCasePropertyMetadata');
+        $metadata->addPropertyMetadata(new PropertyMetadata('JMS\SerializerBundle\Tests\Serializer\Naming\camelCasePropertyMetadata', 'camelCaseProperty'));
+
+        $translatedPropertyName = $camelCaseNamingStrategy->translateName($metadata->propertyMetadata['camelCaseProperty']);
+
+        $this->assertEquals($translatedPropertyName, 'CamelCaseProperty');
+    }
+}
+
+class CamelCasePropertyMetadata
+{
+    private $camelCaseProperty;
+}


### PR DESCRIPTION
Hi, camel case naming offers two ways to write camel case :
- UpperCamelCase, with the first letter on uppercase
- lowerCamelCase, with the first letter on lowercase

This pull request handle the use of lowerCamelCase naming, by adding a boolean configuration node "lower_camel_case". The use of UpperCamelCase is used by default or if the configuration node "lower_camel_case" is set to "false"
