### PR TITLE
allowed expose annotation on methods

### DIFF
--- a/Annotation/Expose.php
+++ b/Annotation/Expose.php
@@ -20,7 +20,7 @@ namespace JMS\SerializerBundle\Annotation;
 
 /**
  * @Annotation
- * @Target("PROPERTY")
+ * @Target({"PROPERTY","METHOD"})
  */
 final class Expose
 {


### PR DESCRIPTION
When the ExclusionPolicy is set to all, I don't see any way to expose virtualFields? Not sure if it's the correct fix, but allowing expose on methods and adding the expose annotation on the virtualfield method worked for me :)
