### PR TITLE
Support for xmlKeyValuePairs in xml and yml metadata driver

### DIFF
--- a/Metadata/Driver/XmlDriver.php
+++ b/Metadata/Driver/XmlDriver.php
@@ -53,7 +53,7 @@ class XmlDriver extends AbstractFileDriver
 
         $propertiesMetadata = array();
         $propertiesNodes = array();
-        
+
         if (null !== $accessorOrder = $elem->attributes()->{'accessor-order'}) {
             $metadata->setAccessorOrder((string) $accessorOrder, preg_split('/\s*,\s*/', (string) $elem->attributes()->{'custom-accessor-order'}));
         }
@@ -68,24 +68,24 @@ class XmlDriver extends AbstractFileDriver
             }
 
             $virtualPropertyMetadata = new VirtualPropertyMetadata( $name, (string) $method->attributes()->method );
-            
+
             $propertiesMetadata[] = $virtualPropertyMetadata;
             $propertiesNodes[] = $method;
         }
-        
+
         if (!$excludeAll) {
-            
+
             foreach ($class->getProperties() as $property) {
                 if ($name !== $property->getDeclaringClass()->getName()) {
                     continue;
                 }
-                
+
                 $propertiesMetadata[] = new PropertyMetadata($name, $pName = $property->getName());
                 $pElems = $elem->xpath("./property[@name = '".$pName."']");
-                
+
                 $propertiesNodes[] = $pElems ? reset( $pElems ) : null;
             }
-            
+
             foreach ($propertiesMetadata as $propertyKey => $pMetadata) {
 
                 $isExclude = $isExpose = false;
@@ -121,7 +121,7 @@ class XmlDriver extends AbstractFileDriver
 
                     if (null !== $groups = $pElem->attributes()->groups) {
                         $pMetadata->groups =  preg_split('/\s*,\s*/', (string) $groups);
-                    } 
+                    }
 
                     if (isset($pElem->{'xml-list'})) {
                         $pMetadata->xmlCollection = true;
@@ -159,6 +159,10 @@ class XmlDriver extends AbstractFileDriver
 
                     if (isset($pElem->attributes()->{'xml-value'})) {
                         $pMetadata->xmlValue = 'true' === (string) $pElem->attributes()->{'xml-value'};
+                    }
+
+                    if (isset($pElem->attributes()->{'xml-key-value-pairs'})) {
+                        $pMetadata->xmlKeyValuePairs = 'true' === (string) $pElem->attributes()->{'xml-key-value-pairs'};
                     }
 
                     $getter = $pElem->attributes()->{'accessor-getter'};

--- a/Metadata/Driver/YamlDriver.php
+++ b/Metadata/Driver/YamlDriver.php
@@ -110,7 +110,7 @@ class YamlDriver extends AbstractFileDriver
                     }
                     if (isset($pConfig['groups'])) {
                         $pMetadata->groups = $pConfig['groups'];
-                    } 
+                    }
 
                     if (isset($pConfig['xml_list'])) {
                         $pMetadata->xmlCollection = true;
@@ -148,6 +148,10 @@ class YamlDriver extends AbstractFileDriver
 
                     if (isset($pConfig['xml_value'])) {
                         $pMetadata->xmlValue = (Boolean) $pConfig['xml_value'];
+                    }
+
+                    if (isset($pConfig['xml_key_value_pairs'])) {
+                        $pMetadata->xmlKeyValuePairs = (Boolean) $pConfig['xml_key_value_pairs'];
                     }
 
                     $pMetadata->setAccessor(

--- a/Resources/doc/reference/xml_reference.rst
+++ b/Resources/doc/reference/xml_reference.rst
@@ -22,6 +22,7 @@ XML Reference
                       inline="true"
                       read-only="true"
                       groups="foo,bar"
+                      xml-key-value-pairs="true"
             >
                 <!-- You can also specify the type as element which is necessary if
                      your type contains "<" or ">" characters. -->

--- a/Resources/doc/reference/yml_reference.rst
+++ b/Resources/doc/reference/yml_reference.rst
@@ -23,6 +23,7 @@ YAML Reference
                 xml_attribute: true
                 inline: true
                 read_only: true
+                xml_key_value_pairs: true
                 xml_list:
                     inline: true
                     entry_name: foo

--- a/Tests/Metadata/Driver/BaseDriverTest.php
+++ b/Tests/Metadata/Driver/BaseDriverTest.php
@@ -60,10 +60,10 @@ abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
         $p->type = 'JMS\SerializerBundle\Tests\Fixtures\Author';
         $p->groups = array("post");
         $this->assertEquals($p, $m->propertyMetadata['author']);
-        
+
         $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\SerializerBundle\Tests\Fixtures\Price'));
         $this->assertNotNull($m);
-        
+
         $p = new PropertyMetadata($m->name, 'price');
         $p->type = 'double';
         $p->xmlValue = true;
@@ -84,6 +84,14 @@ abstract class BaseDriverTest extends \PHPUnit_Framework_TestCase
         $p->getter = 'getVirtualValue';
 
         $this->assertEquals($p, $m->propertyMetadata['virtualValue']);
+    }
+
+    public function testXmlKeyValuePairs()
+    {
+        $m = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\SerializerBundle\Tests\Fixtures\ObjectWithXmlKeyValuePairs'));
+
+        $this->assertArrayHasKey('array', $m->propertyMetadata);
+        $this->assertTrue($m->propertyMetadata['array']->xmlKeyValuePairs);
     }
 
     abstract protected function getDriver();

--- a/Tests/Metadata/Driver/php/ObjectWithXmlKeyValuePairs.php
+++ b/Tests/Metadata/Driver/php/ObjectWithXmlKeyValuePairs.php
@@ -1,0 +1,13 @@
+<?php
+use JMS\SerializerBundle\Metadata\ClassMetadata;
+use JMS\SerializerBundle\Metadata\PropertyMetadata;
+
+$className = 'JMS\SerializerBundle\Tests\Fixtures\ObjectWithXmlKeyValuePairs';
+
+$metadata = new ClassMetadata($className);
+
+$pMetadata = new PropertyMetadata($className, 'array');
+$pMetadata->xmlKeyValuePairs = true;
+$metadata->addPropertyMetadata($pMetadata);
+
+return $metadata;

--- a/Tests/Metadata/Driver/xml/ObjectWithXmlKeyValuePairs.xml
+++ b/Tests/Metadata/Driver/xml/ObjectWithXmlKeyValuePairs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="JMS\SerializerBundle\Tests\Fixtures\ObjectWithXmlKeyValuePairs" >
+        <property name="array" type="array" xml-key-value-pairs="true" />
+    </class>
+</serializer>

--- a/Tests/Metadata/Driver/yml/ObjectWithXmlKeyValuePairs.yml
+++ b/Tests/Metadata/Driver/yml/ObjectWithXmlKeyValuePairs.yml
@@ -1,0 +1,5 @@
+JMS\SerializerBundle\Tests\Fixtures\ObjectWithXmlKeyValuePairs:
+    properties:
+        array:
+            type: array
+            xml_key_value_pairs: true


### PR DESCRIPTION
This PR adds the missing support for xmlKeyValuePairs in the xml and yml metadata driver.
