### PR TITLE
Fixed missing support for Accessor in YamlDriver

### DIFF
--- a/Metadata/Driver/YamlDriver.php
+++ b/Metadata/Driver/YamlDriver.php
@@ -158,7 +158,8 @@ class YamlDriver extends AbstractFileDriver
 
                     $pMetadata->setAccessor(
                         isset($pConfig['access_type']) ? $pConfig['access_type'] : $classAccessType,
-                        isset($pConfig['accessor']) ? $pConfig['accessor'] : null
+                        isset($pConfig['accessor']['getter']) ? $pConfig['accessor']['getter'] : null,
+                        isset($pConfig['accessor']['setter']) ? $pConfig['accessor']['setter'] : null
                     );
 
                     if (isset($pConfig['inline'])) {

--- a/Resources/doc/reference/yml_reference.rst
+++ b/Resources/doc/reference/yml_reference.rst
@@ -15,6 +15,9 @@ YAML Reference
                 exclude: true
                 expose: true
                 access_type: public_method # defaults to property
+                accessor: # access_type must be set to public_method
+                    getter: getSomeOtherProperty
+                    setter: setSomeOtherProperty
                 type: string
                 serialized_name: foo
                 since_version: 1.0


### PR DESCRIPTION
It appears there was an oversight in the YamlDriver which caused it not to support the Accessor config.

This small patch adds support and updates the Yaml reference docs to include an example of how to enable it.

> Note: the line feeds in yml_reference.rst must not have been in unix format because it's showing every line as changed. If you want me to leave the line endings as-is, let me know and I'll update the PR.

This fixes #146 and #148 (dupe of #146).
