### PR TITLE
Options for json_encode

### DIFF
--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -153,6 +153,10 @@ class JMSSerializerExtension extends Extension
             ->getDefinition('jms_serializer.metadata.file_locator')
             ->replaceArgument(0, $directories)
         ;
+
+        $container
+            ->setParameter('jms_serializer.json_serialization_visitor.options', $config['visitors']['json']['options'])
+        ;
     }
 
     public function getConfiguration(array $config, ContainerBuilder $container)

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,10 +12,10 @@
         <parameter key="jms_serializer.metadata.xml_driver.class">JMS\SerializerBundle\Metadata\Driver\XmlDriver</parameter>
         <parameter key="jms_serializer.metadata.php_driver.class">JMS\SerializerBundle\Metadata\Driver\PhpDriver</parameter>
         <parameter key="jms_serializer.metadata.lazy_loading_driver.class">Metadata\Driver\LazyLoadingDriver</parameter>
-        
+
         <parameter key="jms_serializer.metadata.metadata_factory.class">Metadata\MetadataFactory</parameter>
         <parameter key="jms_serializer.metadata.cache.file_cache.class">Metadata\Cache\FileCache</parameter>
-    
+
         <parameter key="jms_serializer.camel_case_naming_strategy.class">JMS\SerializerBundle\Serializer\Naming\CamelCaseNamingStrategy</parameter>
         <parameter key="jms_serializer.serialized_name_annotation_strategy.class">JMS\SerializerBundle\Serializer\Naming\SerializedNameAnnotationStrategy</parameter>
         <parameter key="jms_serializer.cache_naming_strategy.class">JMS\SerializerBundle\Serializer\Naming\CacheNamingStrategy</parameter>
@@ -27,13 +27,14 @@
         <parameter key="jms_serializer.serializer.class">JMS\SerializerBundle\Serializer\LazyLoadingSerializer</parameter>
 
         <parameter key="jms_serializer.twig_extension.class">JMS\SerializerBundle\Twig\SerializerExtension</parameter>
-        
+
         <parameter key="jms_serializer.json_serialization_visitor.class">JMS\SerializerBundle\Serializer\JsonSerializationVisitor</parameter>
+        <parameter key="jms_serializer.json_serialization_visitor.options" type="collection"></parameter>
         <parameter key="jms_serializer.json_deserialization_visitor.class">JMS\SerializerBundle\Serializer\JsonDeserializationVisitor</parameter>
         <parameter key="jms_serializer.xml_serialization_visitor.class">JMS\SerializerBundle\Serializer\XmlSerializationVisitor</parameter>
         <parameter key="jms_serializer.xml_deserialization_visitor.class">JMS\SerializerBundle\Serializer\XmlDeserializationVisitor</parameter>
         <parameter key="jms_serializer.yaml_serialization_visitor.class">JMS\SerializerBundle\Serializer\YamlSerializationVisitor</parameter>
-        
+
         <parameter key="jms_serializer.object_based_custom_handler.class">JMS\SerializerBundle\Serializer\Handler\ObjectBasedCustomHandler</parameter>
         <parameter key="jms_serializer.datetime_handler.class">JMS\SerializerBundle\Serializer\Handler\DateTimeHandler</parameter>
         <parameter key="jms_serializer.array_collection_handler.class">JMS\SerializerBundle\Serializer\Handler\ArrayCollectionHandler</parameter>
@@ -127,6 +128,9 @@
         <service id="jms_serializer.json_serialization_visitor" class="%jms_serializer.json_serialization_visitor.class%" public="false">
             <argument type="service" id="jms_serializer.naming_strategy" />
             <argument type="collection" /><!-- Custom Handlers -->
+            <call method="setOptions">
+                <argument>%jms_serializer.json_serialization_visitor.options%</argument>
+            </call>
             <tag name="jms_serializer.serialization_visitor" format="json" />
         </service>
         <service id="jms_serializer.json_deserialization_visitor" class="%jms_serializer.json_deserialization_visitor.class%" public="false">
@@ -151,7 +155,7 @@
             <argument type="collection" /><!-- Custom Handlers -->
             <tag name="jms_serializer.serialization_visitor" format="yml" />
         </service>
-        
+
         <!-- Custom Handlers -->
         <service id="jms_serializer.object_based_custom_handler" class="%jms_serializer.object_based_custom_handler.class%" public="false">
             <argument type="service" id="jms_serializer.unserialize_object_constructor" />

--- a/Serializer/JsonSerializationVisitor.php
+++ b/Serializer/JsonSerializationVisitor.php
@@ -20,8 +20,20 @@ namespace JMS\SerializerBundle\Serializer;
 
 class JsonSerializationVisitor extends GenericSerializationVisitor
 {
+    private $options = 0;
+
     public function getResult()
     {
-        return json_encode($this->getRoot());
+        return json_encode($this->getRoot(), $this->getOptions());
+    }
+
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    public function setOptions($options)
+    {
+        $this->options = $options;
     }
 }

--- a/Tests/DependencyInjection/JMSSerializerExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSerializerExtensionTest.php
@@ -87,6 +87,42 @@ class JMSSerializerExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(json_encode(array('name' => 'bar')), $serializer->serialize($versionedObject, 'json'));
     }
 
+    public function testJsonVisitorOptions()
+    {
+        $configs = array(
+            384 => array(array(
+                'visitors' => array(
+                    'json' => array(
+                        'options' => array('JSON_UNESCAPED_UNICODE', 'JSON_PRETTY_PRINT')
+                    )
+                )
+            )),
+            256 => array(array(
+                'visitors' => array(
+                    'json' => array(
+                        'options' => 'JSON_UNESCAPED_UNICODE'
+                    )
+                )
+            )),
+            128 => array(array(
+                'visitors' => array(
+                    'json' => array(
+                        'options' => 128
+                    )
+                )
+            )),
+            0 => array(array())
+        );
+
+        foreach ($configs as $jsonOptions => $config) {
+            $container = $this->getContainerForConfig($config);
+
+            $jsonSerializationVisitor = $container->get('jms_serializer.json_serialization_visitor');
+
+            $this->assertEquals($jsonOptions, $jsonSerializationVisitor->getOptions());
+        }
+    }
+
     private function getContainerForConfig(array $configs, KernelInterface $kernel = null)
     {
         if (null === $kernel) {


### PR DESCRIPTION
Since 5.4 in function json_encode were added useful options such as JSON_UNESCAPED_UNICODE that correctly serialize Non-latin symbols.
Without option:

``` json
{
    "fullname":"\u0412\u0430\u0441\u044f \u041f\u0435\u0442\u0440\u043e\u0432"
}
```

With option:

``` json
{
    "fullname": "Вася Петров"
}
```
