### PR TITLE
Added option for property_naming

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -60,6 +60,7 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('separator')->defaultValue('_')->end()
                     ->booleanNode('lower_case')->defaultTrue()->end()
                     ->booleanNode('enable_cache')->defaultTrue()->end()
+                    ->booleanNode('ucfirst')->defaultTrue()->end()
                 ->end()
             ->end()
         ;

--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -63,6 +63,7 @@ class JMSSerializerExtension extends Extension
             ->getDefinition('jms_serializer.camel_case_naming_strategy')
             ->addArgument($config['property_naming']['separator'])
             ->addArgument($config['property_naming']['lower_case'])
+            ->addArgument($config['property_naming']['ucfirst'])
         ;
         if ($config['property_naming']['enable_cache']) {
             $container

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -14,7 +14,7 @@ values:
 .. configuration-block ::
 
     .. code-block :: yaml
-    
+
         # config.yml
         jms_serializer:
             handlers:
@@ -25,17 +25,18 @@ values:
                 array_collection: true
                 form_error: true
                 constraint_violation: true
-    
+
             property_naming:
                 separator:  _
                 lower_case: true
-    
+                ucfirst: true
+
             metadata:
                 cache: file
                 debug: "%kernel.debug%"
                 file_cache:
                     dir: "%kernel.cache_dir%/serializer"
-    
+
                 # Using auto-detection, the mapping files for each bundle will be
                 # expected in the Resources/config/serializer directory.
                 #
@@ -43,7 +44,7 @@ values:
                 # class: My\FooBundle\Entity\User
                 # expected path: @MyFooBundle/Resources/config/serializer/Entity.User.(yml|xml|php)
                 auto_detection: true
-    
+
                 # if you don't want to use auto-detection, you can also define the
                 # namespace prefix and the corresponding directory explicitly
                 directories:
@@ -52,36 +53,36 @@ values:
                         path: "@MyFooBundle/Resources/config/serializer"
                     another-name:
                         namespace_prefix: "My\\BarBundle"
-                        path: "@MyBarBundle/Resources/config/serializer"    
+                        path: "@MyBarBundle/Resources/config/serializer"
 
     .. code-block :: xml
-    
+
         <!-- config.xml -->
         <jms-serializer>
             <handlers>
                 <object-based />
-                <datetime 
+                <datetime
                     format="Y-mdTH:i:s"
                     default-timezone="UTC" />
                 <array-collection />
                 <form-error />
-                <constraint-violation /> 
+                <constraint-violation />
             </handlers>
-            
+
             <property-naming
                 seperator="_"
                 lower-case="true" />
-                
+
             <metadata
                 cache="file"
                 debug="%kernel.debug%"
                 auto-detection="true">
-                
+
                 <file-cache dir="%kernel.cache_dir%/serializer" />
-                
+
                 <!-- If auto-detection is enabled, mapping files for each bundle will
-                     be expected in the Resources/config/serializer directory. 
-                     
+                     be expected in the Resources/config/serializer directory.
+
                      Example:
                      class: My\FooBundle\Entity\User
                      expected path: @MyFooBundle/Resources/config/serializer/Entity.User.(yml|xml|php)
@@ -91,4 +92,3 @@ values:
                     path="@MyFooBundle/Resources/config/serializer" />
             </metadata>
         </jms-serializer>
-    

--- a/Serializer/Naming/CamelCaseNamingStrategy.php
+++ b/Serializer/Naming/CamelCaseNamingStrategy.php
@@ -29,11 +29,13 @@ class CamelCaseNamingStrategy implements PropertyNamingStrategyInterface
 {
     private $separator;
     private $lowerCase;
+    private $ucfirst;
 
-    public function __construct($separator = '_', $lowerCase = true)
+    public function __construct($separator = '_', $lowerCase = true, $ucfirst = true)
     {
         $this->separator = $separator;
         $this->lowerCase = $lowerCase;
+        $this->ucfirst   = $ucfirst;
     }
 
     /**
@@ -49,6 +51,10 @@ class CamelCaseNamingStrategy implements PropertyNamingStrategyInterface
             return strtolower($name);
         }
 
-        return ucfirst($name);
+        if ($this->ucfirst) {
+            return ucfirst($name);
+        }
+
+        return $name;
     }
 }


### PR DESCRIPTION
I want to send data to javascript in mixedCase (lower camel case) format. To do this i need to serialize/deserialize data in this format.

An example of my configuration:

``` YAML
jms_serializer:
    property_naming:
            separator:
            lower_case: false
            ucfirst: false
```
