### PR TITLE
Fixed missing support for Accessor in YamlDriver

### DIFF
--- a/Metadata/Driver/YamlDriver.php
+++ b/Metadata/Driver/YamlDriver.php
@@ -158,7 +158,8 @@ class YamlDriver extends AbstractFileDriver
 
                     $pMetadata->setAccessor(
                         isset($pConfig['access_type']) ? $pConfig['access_type'] : $classAccessType,
-                        isset($pConfig['accessor']) ? $pConfig['accessor'] : null
+                        isset($pConfig['accessor']['getter']) ? $pConfig['accessor']['getter'] : null,
+                        isset($pConfig['accessor']['setter']) ? $pConfig['accessor']['setter'] : null
                     );
 
                     if (isset($pConfig['inline'])) {

--- a/Resources/doc/reference/yml_reference.rst
+++ b/Resources/doc/reference/yml_reference.rst
@@ -15,6 +15,9 @@ YAML Reference
                 exclude: true
                 expose: true
                 access_type: public_method # defaults to property
+                accessor: # access_type must be set to public_method
+                    getter: getSomeOtherProperty
+                    setter: setSomeOtherProperty
                 type: string
                 serialized_name: foo
                 since_version: 1.0

--- a/Tests/Metadata/Driver/YamlDriverTest.php
+++ b/Tests/Metadata/Driver/YamlDriverTest.php
@@ -57,6 +57,18 @@ class YamlDriverTest extends BaseDriverTest
         $this->assertEquals($p, $m->propertyMetadata['title']);
     }
 
+    public function testBlogPostAccessor()
+    {
+        $m = $this->getDriver('accessor')->loadMetadataForClass(new \ReflectionClass('JMS\SerializerBundle\Tests\Fixtures\BlogPost'));
+
+        $this->assertArrayHasKey('title', $m->propertyMetadata);
+
+        $p = new PropertyMetadata($m->name, 'title');
+        $p->getter = 'getOtherTitle';
+        $p->setter = 'setOtherTitle';
+        $this->assertEquals($p, $m->propertyMetadata['title']);
+    }
+
     protected function getDriver()
     {
         $append = '';

--- a/Tests/Metadata/Driver/yml/accessor/BlogPost.yml
+++ b/Tests/Metadata/Driver/yml/accessor/BlogPost.yml
@@ -1,0 +1,7 @@
+JMS\SerializerBundle\Tests\Fixtures\BlogPost:
+    xml_root_name: blog-post
+    properties:
+        title:
+            accessor:
+                getter: getOtherTitle
+                setter: setOtherTitle


### PR DESCRIPTION
It appears there was an oversight in the YamlDriver which caused it not to support the Accessor config.

This small patch adds support and updates the Yaml reference docs to include an example of how to enable it.

> Note: the line feeds in yml_reference.rst must not have been in unix format because it's showing every line as changed. If you want me to leave the line endings as-is, let me know and I'll update the PR.

This fixes #146 and #148 (dupe of #146).

This is a re-submitted copy of #150 because I messed up the merge.
