### PR TITLE
Feature to allow child objects to choose which fields to display from their parent.

### DIFF
--- a/Annotation/MapFields.php
+++ b/Annotation/MapFields.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace JMS\SerializerBundle\Annotation;
+
+use JMS\SerializerBundle\Exception\RuntimeException;
+
+/**
+ * @Annotation
+ * @Target("PROPERTY")
+ *
+ * @author Zach Badgett <zach.badgett@gmail.com>
+ */
+final class MapFields
+{
+    public $fields;
+
+    public function __construct(array $values)
+    {
+        if (!isset($values['value']) || !is_array($values['value'])) {
+            throw new RuntimeException('$fields must be an array.');
+        }
+
+        $this->fields = $values['value'];
+    }
+}

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -46,6 +46,7 @@ use JMS\SerializerBundle\Annotation\Since;
 use JMS\SerializerBundle\Annotation\ExclusionPolicy;
 use JMS\SerializerBundle\Annotation\Inline;
 use JMS\SerializerBundle\Annotation\ReadOnly;
+use JMS\SerializerBundle\Annotation\MapFields;
 use JMS\SerializerBundle\Metadata\ClassMetadata;
 use JMS\SerializerBundle\Metadata\PropertyMetadata;
 use JMS\SerializerBundle\Metadata\VirtualPropertyMetadata;
@@ -167,6 +168,8 @@ class AnnotationDriver implements DriverInterface
                         $propertyMetadata->inline = true;
                     } else if ($annot instanceof ReadOnly) {
                         $propertyMetadata->readOnly = true;
+                    } else if ($annot instanceof MapFields) {
+                        $propertyMetadata->mapFields = $annot->fields;
                     }
                 }
 

--- a/Metadata/PropertyMetadata.php
+++ b/Metadata/PropertyMetadata.php
@@ -41,6 +41,7 @@ class PropertyMetadata extends BasePropertyMetadata
     public $setter;
     public $inline = false;
     public $readOnly = false;
+    public $mapFields = array();
 
     public function setAccessor($type, $getter = null, $setter = null)
     {
@@ -89,6 +90,7 @@ class PropertyMetadata extends BasePropertyMetadata
             $this->setter,
             $this->inline,
             $this->readOnly,
+            $this->mapFields,
             parent::serialize(),
         ));
     }
@@ -112,6 +114,7 @@ class PropertyMetadata extends BasePropertyMetadata
             $this->setter,
             $this->inline,
             $this->readOnly,
+            $this->mapFields,
             $parentStr
         ) = unserialize($str);
 

--- a/Serializer/GenericSerializationVisitor.php
+++ b/Serializer/GenericSerializationVisitor.php
@@ -142,7 +142,7 @@ abstract class GenericSerializationVisitor extends AbstractSerializationVisitor
                         $o[$field] = $v->$method();
                     }
                 }
-                $v = (sizeof($o) === 1) ? array_shift(array_values($o)) : $o;
+                $v = (sizeof($o) === 1) ? $o[key($o)] : $o;
             }
         }
 

--- a/Serializer/GenericSerializationVisitor.php
+++ b/Serializer/GenericSerializationVisitor.php
@@ -132,8 +132,7 @@ abstract class GenericSerializationVisitor extends AbstractSerializationVisitor
         $v = (null === $metadata->getter ? $metadata->reflection->getValue($data)
                 : $data->{$metadata->getter}());
 
-        if (is_object($v)) {
-            if (!empty($metadata->mapFields)) {
+        if (is_object($v) && !empty($metadata->mapFields)) {
                 $o = array();
                 foreach ($metadata->mapFields as $field) {
                     $method = 'get'.preg_replace_callback('/(^|_|\.)+(.)/', function ($match) { return ('.' === $match[1] ? '_' : '').strtoupper($match[2]); }, $field);
@@ -142,8 +141,7 @@ abstract class GenericSerializationVisitor extends AbstractSerializationVisitor
                         $o[$field] = $v->$method();
                     }
                 }
-                $v = (sizeof($o) === 1) ? $o[key($o)] : $o;
-            }
+                $v = (count($o) === 1) ? $o[key($o)] : $o;
         }
 
         $v = $this->navigator->accept($v, null, $this);

--- a/Serializer/GenericSerializationVisitor.php
+++ b/Serializer/GenericSerializationVisitor.php
@@ -132,6 +132,20 @@ abstract class GenericSerializationVisitor extends AbstractSerializationVisitor
         $v = (null === $metadata->getter ? $metadata->reflection->getValue($data)
                 : $data->{$metadata->getter}());
 
+        if (is_object($v)) {
+            if (!empty($metadata->mapFields)) {
+                $o = array();
+                foreach ($metadata->mapFields as $field) {
+                    $method = 'get'.preg_replace_callback('/(^|_|\.)+(.)/', function ($match) { return ('.' === $match[1] ? '_' : '').strtoupper($match[2]); }, $field);
+
+                    if (method_exists($v, $method)) {
+                        $o[$field] = $v->$method();
+                    }
+                }
+                $v = (sizeof($o) === 1) ? array_shift(array_values($o)) : $o;
+            }
+        }
+
         $v = $this->navigator->accept($v, null, $this);
         if (null === $v) {
             return;

--- a/Serializer/XmlSerializationVisitor.php
+++ b/Serializer/XmlSerializationVisitor.php
@@ -166,7 +166,7 @@ class XmlSerializationVisitor extends AbstractSerializationVisitor
                         $o[$field] = $v->$method();
                     }
                 }
-                $v = (sizeof($o) === 1) ? array_shift(array_values($o)) : $o;
+                $v = (sizeof($o) === 1) ? $o[key($o)] : $o;
             }
         }
 

--- a/Serializer/XmlSerializationVisitor.php
+++ b/Serializer/XmlSerializationVisitor.php
@@ -156,18 +156,16 @@ class XmlSerializationVisitor extends AbstractSerializationVisitor
             return;
         }
 
-        if (is_object($v)) {
-            if (!empty($metadata->mapFields)) {
-                $o = array();
-                foreach ($metadata->mapFields as $field) {
-                    $method = 'get'.preg_replace_callback('/(^|_|\.)+(.)/', function ($match) { return ('.' === $match[1] ? '_' : '').strtoupper($match[2]); }, $field);
+        if (is_object($v) && !empty($metadata->mapFields)) {
+            $o = array();
+            foreach ($metadata->mapFields as $field) {
+                $method = 'get'.preg_replace_callback('/(^|_|\.)+(.)/', function ($match) { return ('.' === $match[1] ? '_' : '').strtoupper($match[2]); }, $field);
 
-                    if (method_exists($v, $method)) {
-                        $o[$field] = $v->$method();
-                    }
+                if (method_exists($v, $method)) {
+                    $o[$field] = $v->$method();
                 }
-                $v = (sizeof($o) === 1) ? $o[key($o)] : $o;
             }
+            $v = (count($o) === 1) ? $o[key($o)] : $o;
         }
 
         if ($metadata->xmlAttribute) {

--- a/Serializer/XmlSerializationVisitor.php
+++ b/Serializer/XmlSerializationVisitor.php
@@ -156,6 +156,20 @@ class XmlSerializationVisitor extends AbstractSerializationVisitor
             return;
         }
 
+        if (is_object($v)) {
+            if (!empty($metadata->mapFields)) {
+                $o = array();
+                foreach ($metadata->mapFields as $field) {
+                    $method = 'get'.preg_replace_callback('/(^|_|\.)+(.)/', function ($match) { return ('.' === $match[1] ? '_' : '').strtoupper($match[2]); }, $field);
+
+                    if (method_exists($v, $method)) {
+                        $o[$field] = $v->$method();
+                    }
+                }
+                $v = (sizeof($o) === 1) ? array_shift(array_values($o)) : $o;
+            }
+        }
+
         if ($metadata->xmlAttribute) {
             $node = $this->navigator->accept($v, null, $this);
             if (!$node instanceof \DOMCharacterData) {

--- a/Serializer/YamlSerializationVisitor.php
+++ b/Serializer/YamlSerializationVisitor.php
@@ -154,18 +154,16 @@ class YamlSerializationVisitor extends AbstractSerializationVisitor
             return;
         }
 
-        if (is_object($v)) {
-            if (!empty($metadata->mapFields)) {
-                $o = array();
-                foreach ($metadata->mapFields as $field) {
-                    $method = 'get'.preg_replace_callback('/(^|_|\.)+(.)/', function ($match) { return ('.' === $match[1] ? '_' : '').strtoupper($match[2]); }, $field);
+        if (is_object($v) && !empty($metadata->mapFields)) {
+            $o = array();
+            foreach ($metadata->mapFields as $field) {
+                $method = 'get'.preg_replace_callback('/(^|_|\.)+(.)/', function ($match) { return ('.' === $match[1] ? '_' : '').strtoupper($match[2]); }, $field);
 
-                    if (method_exists($v, $method)) {
-                        $o[$field] = $v->$method();
-                    }
+                if (method_exists($v, $method)) {
+                    $o[$field] = $v->$method();
                 }
-                $v = (sizeof($o) === 1) ? $o[key($o)] : $o;
             }
+            $v = (count($o) === 1) ? $o[key($o)] : $o;
         }
 
         $name = $this->namingStrategy->translateName($metadata);

--- a/Serializer/YamlSerializationVisitor.php
+++ b/Serializer/YamlSerializationVisitor.php
@@ -154,6 +154,20 @@ class YamlSerializationVisitor extends AbstractSerializationVisitor
             return;
         }
 
+        if (is_object($v)) {
+            if (!empty($metadata->mapFields)) {
+                $o = array();
+                foreach ($metadata->mapFields as $field) {
+                    $method = 'get'.preg_replace_callback('/(^|_|\.)+(.)/', function ($match) { return ('.' === $match[1] ? '_' : '').strtoupper($match[2]); }, $field);
+
+                    if (method_exists($v, $method)) {
+                        $o[$field] = $v->$method();
+                    }
+                }
+                $v = (sizeof($o) === 1) ? array_shift(array_values($o)) : $o;
+            }
+        }
+
         $name = $this->namingStrategy->translateName($metadata);
 
         if (!$metadata->inline) {

--- a/Serializer/YamlSerializationVisitor.php
+++ b/Serializer/YamlSerializationVisitor.php
@@ -164,7 +164,7 @@ class YamlSerializationVisitor extends AbstractSerializationVisitor
                         $o[$field] = $v->$method();
                     }
                 }
-                $v = (sizeof($o) === 1) ? array_shift(array_values($o)) : $o;
+                $v = (sizeof($o) === 1) ? $o[key($o)] : $o;
             }
         }
 

--- a/Tests/Fixtures/ChildObjectWithMapFields.php
+++ b/Tests/Fixtures/ChildObjectWithMapFields.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace JMS\SerializerBundle\Tests\Fixtures;
+
+use JMS\SerializerBundle\Annotation\AccessorOrder;
+use JMS\SerializerBundle\Annotation\Type;
+use JMS\SerializerBundle\Annotation\VirtualProperty;
+use JMS\SerializerBundle\Annotation\SerializedName;
+use JMS\SerializerBundle\Annotation\Exclude;
+use JMS\SerializerBundle\Annotation\MapFields;
+
+class ChildObjectWithMapFields
+{
+
+    /**
+     * @Type("JMS\SerializerBundle\Tests\Fixtures\Comment")
+     * @SerializedName("Comment")
+     * @MapFields({"author"})
+     */
+    protected $parent;
+
+    public function __construct(Comment $comment)
+    {
+        $this->parent = $comment;
+    }
+
+    public function getParent()
+    {
+        return $this->parent;
+    }
+}

--- a/Tests/Serializer/BaseSerializationTest.php
+++ b/Tests/Serializer/BaseSerializationTest.php
@@ -46,6 +46,7 @@ use JMS\SerializerBundle\Tests\Fixtures\AuthorList;
 use JMS\SerializerBundle\Tests\Fixtures\AuthorReadOnly;
 use JMS\SerializerBundle\Tests\Fixtures\BlogPost;
 use JMS\SerializerBundle\Tests\Fixtures\CircularReferenceParent;
+use JMS\SerializerBundle\Tests\Fixtures\ChildObjectWithMapFields;
 use JMS\SerializerBundle\Tests\Fixtures\Comment;
 use JMS\SerializerBundle\Tests\Fixtures\CurrencyAwareOrder;
 use JMS\SerializerBundle\Tests\Fixtures\CurrencyAwarePrice;
@@ -208,6 +209,15 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
             $this->assertNull($this->getField($deserialized, 'id'));
             $this->assertEquals('Ruud Kamphuis', $this->getField($deserialized, 'name'));
         }
+    }
+
+    public function testMapFields()
+    {
+        $author = new Author('Foo Bar');
+        $comment = new Comment($author, 'Foo');
+        $childObject = new ChildObjectWithMapFields($comment);
+        $data = $this->serialize($childObject);
+        $this->assertEquals($this->getContent('map_fields'), $data);
     }
 
     public function testPrice()

--- a/Tests/Serializer/JsonSerializationTest.php
+++ b/Tests/Serializer/JsonSerializationTest.php
@@ -68,6 +68,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['virtual_properties_low'] = '{"low":1}';
             $outputs['virtual_properties_high'] = '{"high":8}';
             $outputs['virtual_properties_all'] = '{"low":1,"high":8}';
+            $outputs['map_fields'] = '{"Comment":{"full_name":"Foo Bar"}}';
         }
 
         if (!isset($outputs[$key])) {

--- a/Tests/Serializer/xml/map_fields.xml
+++ b/Tests/Serializer/xml/map_fields.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <Comment>
+    <full_name><![CDATA[Foo Bar]]></full_name>
+  </Comment>
+</result>

--- a/Tests/Serializer/yml/map_fields.yml
+++ b/Tests/Serializer/yml/map_fields.yml
@@ -1,0 +1,2 @@
+Comment:
+    full_name: 'Foo Bar'


### PR DESCRIPTION
This can come in handy when you want to serialize an object that has a parent but only want to display certain fields that differ from the parents' policies. An example:

``` php

/**
 * @ORM\ManyToOne(targetEntity="Parent", inversedBy="child")
 * @ORM\JoinColumn(name="parent_id", referencedColumnName="id")
 *
 * @JMS\SerializedName("parent_id")
 * @JMS\MapFields({"id"})
 */
protected $parent;

```

The code above would produce an output with one of the child's values being parent_id:(parent's id). If multiple fields are given you would see parent_id: { id: (parent's id), field: (extra field value) }.
