### PR TITLE
Name virtual properties to avoid name collision

### DIFF
--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -103,7 +103,8 @@ class AnnotationDriver implements DriverInterface
                     $classMetadata->addPostSerializeMethod(new MethodMetadata($name, $method->getName()));
                     continue 2;
                 } else if ($annot instanceof VirtualProperty) {
-                    $virtualPropertyMetadata = new VirtualPropertyMetadata($name, $method->getName());
+                    $propertyName = $annot->name ?: $method->getName();
+                    $virtualPropertyMetadata = new VirtualPropertyMetadata($name, $propertyName, $method->getName());
                     $propertiesMetadata[] = $virtualPropertyMetadata;
                     $propertiesAnnotations[] = $methodAnnotations;
                     continue 2;

--- a/Metadata/Driver/XmlDriver.php
+++ b/Metadata/Driver/XmlDriver.php
@@ -62,12 +62,16 @@ class XmlDriver extends AbstractFileDriver
             $metadata->xmlRootName = (string) $xmlRootName;
         }
 
-        foreach ($elem->xpath('./virtual-property') as $method) {
+        $virtualProperties = $elem->xpath('./virtual-property');
+        foreach ($virtualProperties as $method) {
             if (!isset($method->attributes()->method)) {
                 throw new RuntimeException('The method attribute must be set for all virtual-property elements.');
             }
 
-            $virtualPropertyMetadata = new VirtualPropertyMetadata( $name, (string) $method->attributes()->method );
+            $methodName   = (string) $method->attributes()->method;
+            $propertyName = $method->attributes()->name ?: $methodName;
+
+            $virtualPropertyMetadata = new VirtualPropertyMetadata( $name, (string) $propertyName, $methodName );
 
             $propertiesMetadata[] = $virtualPropertyMetadata;
             $propertiesNodes[] = $method;

--- a/Metadata/Driver/YamlDriver.php
+++ b/Metadata/Driver/YamlDriver.php
@@ -63,7 +63,9 @@ class YamlDriver extends AbstractFileDriver
                     throw new RuntimeException('The method '.$methodName.' not found in class ' . $class->name);
                 }
 
-                $virtualPropertyMetadata = new VirtualPropertyMetadata( $name, $methodName );
+                $propertyName = ($propertySettings['name']) ?: $methodName;
+
+                $virtualPropertyMetadata = new VirtualPropertyMetadata( $name, $propertyName, $methodName );
 
                 $propertiesMetadata[$methodName] = $virtualPropertyMetadata;
                 $config['properties'][$methodName] = $propertySettings;

--- a/Metadata/VirtualPropertyMetadata.php
+++ b/Metadata/VirtualPropertyMetadata.php
@@ -22,16 +22,10 @@ namespace JMS\SerializerBundle\Metadata;
 class VirtualPropertyMetadata extends PropertyMetadata
 {
 
-    public function __construct($class, $methodName)
+    public function __construct($class, $name, $methodName)
     {
-        if ('get' === substr($methodName, 0, 3)) {
-            $fieldName = lcfirst(substr($methodName, 3));
-        } else {
-            $fieldName = $methodName;
-        }
-
         $this->class = $class;
-        $this->name = $fieldName;
+        $this->name = $name;
         $this->getter = $methodName;
         $this->readOnly = true;
     }


### PR DESCRIPTION
Allow user to name virtual properties. 

It keeps the same behavior as expected but now you can add a name to avoid conflicts:

example:

`getId` must be returned as `<id></id>` on group `GROUP1`
`getId` must be returned as `<identifier></identifier>` on group `GROUP2`

Or Group1 would like different accessors, etc ...
