### PR TITLE
Updated YmlDriver to support accessor config and fixed read_only "bug"

### DIFF
--- a/Metadata/Driver/YamlDriver.php
+++ b/Metadata/Driver/YamlDriver.php
@@ -166,8 +166,8 @@ class YamlDriver extends AbstractFileDriver
 
                     $pMetadata->setAccessor(
                         isset($pConfig['access_type']) ? $pConfig['access_type'] : $classAccessType,
-                        isset($pConfig['accessor_getter']) ? $pConfig['accessor_getter'] : null,
-                        isset($pConfig['accessor_setter']) ? $pConfig['accessor_setter'] : null
+                        isset($pConfig['accessor']['getter']) ? $pConfig['accessor']['getter'] : null,
+                        isset($pConfig['accessor']['setter']) ? $pConfig['accessor']['setter'] : null
                     );
                 }
                 if ((ExclusionPolicy::NONE === $exclusionPolicy && !$isExclude)


### PR DESCRIPTION
Fixed an issue where setAccessor was called before $pMetadata->readOnly was
assigned, which meant that deserialization would require a public setter for a
readonly property (which may not exist, e.g. in generated Doctrine2 entities).

Also added support for the accessor_getter and accessor_setter config options
in YML, which are supported in the XmlDriver but not in YmlDriver.
