### PR TITLE
Fix deserialization with custom handlers

### DIFF
--- a/Serializer/GenericDeserializationVisitor.php
+++ b/Serializer/GenericDeserializationVisitor.php
@@ -205,6 +205,16 @@ abstract class GenericDeserializationVisitor extends AbstractDeserializationVisi
         return false;
     }
 
+    public function visitUsingCustomHandler($data, $type, &$visited)
+    {
+        $rs =  parent::visitUsingCustomHandler($data, $type, $visited);
+        if (null === $this->result && $visited) {
+            $this->result = $rs;
+        }
+        return $rs;
+    }
+
+
     public function getResult()
     {
         return $this->result;

--- a/Serializer/XmlDeserializationVisitor.php
+++ b/Serializer/XmlDeserializationVisitor.php
@@ -269,6 +269,15 @@ class XmlDeserializationVisitor extends AbstractDeserializationVisitor
         return false;
     }
 
+    public function visitUsingCustomHandler($data, $type, &$visited)
+    {
+        $rs =  parent::visitUsingCustomHandler($data, $type, $visited);
+        if (null === $this->result && $visited) {
+            $this->result = $rs;
+        }
+        return $rs;
+    }
+
     public function setCurrentObject($object)
     {
         $this->objectStack->push($this->currentObject);

--- a/Tests/Fixtures/CustomDeserializationObject.php
+++ b/Tests/Fixtures/CustomDeserializationObject.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace JMS\SerializerBundle\Tests\Fixtures;
+
+use JMS\SerializerBundle\Annotation\Type;
+
+class CustomDeserializationObject
+{
+    /**
+     * @Type("string")
+     */
+    public $someProperty;
+
+    public function __construct($value)
+    {
+        $this->someProperty = $value;
+    }
+}

--- a/Tests/Serializer/BaseSerializationTest.php
+++ b/Tests/Serializer/BaseSerializationTest.php
@@ -49,6 +49,7 @@ use JMS\SerializerBundle\Tests\Fixtures\CircularReferenceParent;
 use JMS\SerializerBundle\Tests\Fixtures\Comment;
 use JMS\SerializerBundle\Tests\Fixtures\CurrencyAwareOrder;
 use JMS\SerializerBundle\Tests\Fixtures\CurrencyAwarePrice;
+use JMS\SerializerBundle\Tests\Fixtures\CustomDeserializationObject;
 use JMS\SerializerBundle\Tests\Fixtures\GetSetObject;
 use JMS\SerializerBundle\Tests\Fixtures\GroupsObject;
 use JMS\SerializerBundle\Tests\Fixtures\IndexedCommentsBlogPost;
@@ -458,6 +459,16 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->getContent('virtual_properties_high'), $serializer->serialize(new ObjectWithVersionedVirtualProperties(), $this->getFormat()));
     }
 
+    public function testCustomHandler()
+    {
+        if ($this->hasDeserializer()) {
+            $serializer = $this->getSerializer();
+            $serialized = $serializer->serialize(new CustomDeserializationObject('sometext'), $this->getFormat());
+            $object = $serializer->deserialize($serialized, 'JMS\SerializerBundle\Tests\Fixtures\CustomDeserializationObject', $this->getFormat());
+            $this->assertEquals('customly_unserialized_value', $object->someProperty);
+        }
+    }
+
     abstract protected function getContent($key);
     abstract protected function getFormat();
 
@@ -526,6 +537,7 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
         $objectConstructor = new UnserializeObjectConstructor();
 
         $handlers = array(
+            new CustomHandler(),
             new ObjectBasedCustomHandler($objectConstructor, $factory),
             new DateTimeHandler(),
             new ArrayCollectionHandler(),
@@ -620,4 +632,20 @@ class Article implements SerializationHandlerInterface, DeserializationHandlerIn
 
         return $this;
     }
+}
+
+class CustomHandler implements DeserializationHandlerInterface
+{
+
+    public function deserialize(VisitorInterface $visitor, $data, $type, &$handled)
+    {
+        if ('JMS\SerializerBundle\Tests\Fixtures\CustomDeserializationObject' !== $type) {
+            return;
+        }
+
+        $handled = true;
+
+        return new CustomDeserializationObject('customly_unserialized_value');
+    }
+
 }


### PR DESCRIPTION
When deserializing a JSON string with a custom handler the deserialize() returns "null". The $result property of GenericDeserializationVisitor is never set.

The PR adds an overloaded visitUsingCustomHandler() function to GenericDeserializationVisitor class that sets the $result property if it was visited just like visitBoolean, visitString etc.
