### PR TITLE
Serializing anything to a plain PHP array

### DIFF
--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -79,7 +79,7 @@ class JMSSerializerExtension extends ConfigurableExtension
             }
         }
 
-        foreach (array('json', 'xml', 'yaml') as $format) {
+        foreach (array('json', 'xml', 'yaml', 'array') as $format) {
             $container
                 ->getDefinition('jms_serializer.'.$format.'_serialization_visitor')
                 ->replaceArgument(1, $serializationHandlers)

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -17,6 +17,7 @@
         <parameter key="jms_serializer.metadata.cache.file_cache.class">Metadata\Cache\FileCache</parameter>
 
         <parameter key="jms_serializer.camel_case_naming_strategy.class">JMS\SerializerBundle\Serializer\Naming\CamelCaseNamingStrategy</parameter>
+        <parameter key="jms_serializer.property_name_naming_strategy.class">JMS\SerializerBundle\Serializer\Naming\PropertyNameNamingStrategy</parameter>
         <parameter key="jms_serializer.serialized_name_annotation_strategy.class">JMS\SerializerBundle\Serializer\Naming\SerializedNameAnnotationStrategy</parameter>
         <parameter key="jms_serializer.cache_naming_strategy.class">JMS\SerializerBundle\Serializer\Naming\CacheNamingStrategy</parameter>
 
@@ -34,6 +35,7 @@
         <parameter key="jms_serializer.xml_serialization_visitor.class">JMS\SerializerBundle\Serializer\XmlSerializationVisitor</parameter>
         <parameter key="jms_serializer.xml_deserialization_visitor.class">JMS\SerializerBundle\Serializer\XmlDeserializationVisitor</parameter>
         <parameter key="jms_serializer.yaml_serialization_visitor.class">JMS\SerializerBundle\Serializer\YamlSerializationVisitor</parameter>
+        <parameter key="jms_serializer.array_serialization_visitor.class">JMS\SerializerBundle\Serializer\ArraySerializationVisitor</parameter>
 
         <parameter key="jms_serializer.object_based_custom_handler.class">JMS\SerializerBundle\Serializer\Handler\ObjectBasedCustomHandler</parameter>
         <parameter key="jms_serializer.datetime_handler.class">JMS\SerializerBundle\Serializer\Handler\DateTimeHandler</parameter>
@@ -96,8 +98,12 @@
 
         <!-- Naming Strategies -->
         <service id="jms_serializer.camel_case_naming_strategy" class="%jms_serializer.camel_case_naming_strategy.class%" public="false" />
+        <service id="jms_serializer.property_name_naming_strategy" class="%jms_serializer.property_name_naming_strategy.class%" public="false" />
         <service id="jms_serializer.serialized_name_annotation_strategy" class="%jms_serializer.serialized_name_annotation_strategy.class%" public="false">
             <argument type="service" id="jms_serializer.camel_case_naming_strategy" />
+        </service>
+        <service id="jms_serializer.serialized_name_annotation_property_strategy" class="%jms_serializer.serialized_name_annotation_strategy.class%" public="false">
+            <argument type="service" id="jms_serializer.property_name_naming_strategy" />
         </service>
         <service id="jms_serializer.cache_naming_strategy" class="%jms_serializer.cache_naming_strategy.class%" public="false" />
         <service id="jms_serializer.naming_strategy" alias="jms_serializer.serialized_name_annotation_strategy" public="false" />
@@ -154,6 +160,11 @@
             <argument type="service" id="jms_serializer.naming_strategy" />
             <argument type="collection" /><!-- Custom Handlers -->
             <tag name="jms_serializer.serialization_visitor" format="yml" />
+        </service>
+        <service id="jms_serializer.array_serialization_visitor" class="%jms_serializer.array_serialization_visitor.class%" public="false">
+            <argument type="service" id="jms_serializer.serialized_name_annotation_property_strategy" />
+            <argument type="collection" /><!-- Custom Handlers -->
+            <tag name="jms_serializer.serialization_visitor" format="array" />
         </service>
 
         <!-- Custom Handlers -->

--- a/Serializer/ArraySerializationVisitor.php
+++ b/Serializer/ArraySerializationVisitor.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\SerializerBundle\Serializer;
+
+class ArraySerializationVisitor extends GenericSerializationVisitor
+{
+    protected $filterNull = false;
+
+    public function getResult()
+    {
+        return $this->getRoot();
+    }
+
+}

--- a/Serializer/GenericSerializationVisitor.php
+++ b/Serializer/GenericSerializationVisitor.php
@@ -19,9 +19,7 @@
 namespace JMS\SerializerBundle\Serializer;
 
 use JMS\SerializerBundle\Metadata\ClassMetadata;
-
 use JMS\SerializerBundle\Metadata\PropertyMetadata;
-use JMS\SerializerBundle\Serializer\Naming\PropertyNamingStrategyInterface;
 
 abstract class GenericSerializationVisitor extends AbstractSerializationVisitor
 {

--- a/Serializer/Naming/PropertyNameNamingStrategy.php
+++ b/Serializer/Naming/PropertyNameNamingStrategy.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\SerializerBundle\Serializer\Naming;
+
+use JMS\SerializerBundle\Metadata\PropertyMetadata;
+
+/**
+ * Naming strategy which uses property name as it is.
+ *
+ * @author Eugene Dounar <eugene.dounar@gmail.com>
+ */
+class PropertyNameNamingStrategy implements PropertyNamingStrategyInterface
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function translateName(PropertyMetadata $property)
+    {
+        return $property->name;
+    }
+}

--- a/Tests/Serializer/ArraySerializationTest.php
+++ b/Tests/Serializer/ArraySerializationTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\SerializerBundle\Tests\Serializer;
+
+use JMS\SerializerBundle\Exception\RuntimeException;
+
+class ArraySerializationTest extends BaseSerializationTest
+{
+    protected function getContent($key)
+    {
+        static $outputs = array();
+
+        if (!$outputs) {
+            $outputs['readonly'] = array("id" => 123, "full_name" => "Ruud Kamphuis");
+            $outputs['string'] = 'foo';
+            $outputs['boolean_true'] = true;
+            $outputs['boolean_false'] = false;
+            $outputs['integer'] = 1;
+            $outputs['float'] = 4.533;
+            $outputs['float_trailing_zero'] = 1;
+            $outputs['simple_object'] = array('foo' => 'foo', 'moo' => 'bar', 'camelCase' => 'boo');
+            $outputs['circular_reference'] = array(
+                "collection" => array(array("name" => "child1"),array("name" => "child2")),
+                "anotherCollection" => array(array("name" => "child1"),array("name" => "child2"))
+            );
+            $outputs['array_strings'] = array('foo', 'bar');
+            $outputs['array_booleans'] = array(true, false);
+            $outputs['array_integers'] = array(1,3,4);
+            $outputs['array_floats'] = array(1.34,3,6.42);
+            $outputs['array_objects'] = array(array("foo" => "foo", "moo" => "bar", "camelCase" => "boo"), array("foo" => "baz", "moo" => "boo", "camelCase" => "boo"));
+            $outputs['array_mixed'] = array("foo", 1, true, array("foo" => "foo", "moo" => "bar", "camelCase" => "boo"), array(1,3,true));
+            $outputs['blog_post'] = array("title" => "This is a nice title.","createdAt" => "2011-07-30T00:00:00+0000","is_published" => false,"comments" => array(array("author" => array("full_name" => "Foo Bar"),"text" => "foo")),"author" => array("full_name" => "Foo Bar"));
+            $outputs['price'] = array("price" => 3);
+            $outputs['currency_aware_price'] = array("currency" => "EUR","amount" => 2.34);
+            $outputs['order'] = array("cost" => array("price" => 12.34));
+            $outputs['order_with_currency_aware_price'] = array("cost" => array("currency" => "EUR","amount" => 1.23));
+            $outputs['log'] = array("author_list" => array(array("full_name" => "Johannes Schmitt"),array("full_name" => "John Doe")),"comments" => array(array("author" => array("full_name" => "Foo Bar"),"text" => "foo"),array("author" => array("full_name" => "Foo Bar"),"text" => "bar"),array("author" => array("full_name" => "Foo Bar"),"text" => "baz")));
+            $outputs['lifecycle_callbacks'] = array("name" => "Foo Bar");
+            $outputs['form_errors'] = array("This is the form error","Another error");
+            $outputs['nested_form_errors'] = array("errors" => array("This is the form error"),"children" => array("bar" => array("errors" => array("Error of the child form"))));
+            $outputs['constraint_violation'] = array("property_path" => "foo","message" => "Message of violation");
+            $outputs['constraint_violation_list'] = array(array("property_path" => "foo","message" => "Message of violation"),array("property_path" => "bar","message" => "Message of another violation"));
+            $outputs['article'] = array("custom" => "serialized");
+            $outputs['orm_proxy'] = array("foo" => "foo","moo" => "bar","camelCase" => "proxy-boo");
+            $outputs['custom_accessor'] = array("comments" => array("Foo" => array("comments" => array(array("author" => array("full_name" => "Foo"),"text" => "foo"),array("author" => array("full_name" => "Foo"),"text" => "bar")),"count" => 2)));
+            $outputs['mixed_access_types'] = array("id" => 1,"name" => "Johannes","readOnlyProperty" => 42);
+            $outputs['accessor_order_child'] = array("c" => "c","d" => "d","a" => "a","b" => "b");
+            $outputs['accessor_order_parent'] = array("a" => "a","b" => "b");
+            $outputs['inline'] = array("c" => "c","a" => "a","b" => "b","d" => "d");
+            $outputs['groups_all'] = array("foo" => "foo","foobar" => "foobar","bar" => "bar","none" => "none");
+            $outputs['groups_foo'] = array("foo" => "foo","foobar" => "foobar");
+            $outputs['groups_foobar'] = array("foo" => "foo","foobar" => "foobar","bar" => "bar");
+            $outputs['virtual_properties'] = array("existField" => "value","virtualValue" => "value","test" => "other-name");
+            $outputs['virtual_properties_low'] = array("low" => 1);
+            $outputs['virtual_properties_high'] = array("high" => 8);
+            $outputs['virtual_properties_all'] = array("low" => 1,"high" => 8);
+        }
+
+        if (!isset($outputs[$key])) {
+            throw new RuntimeException(sprintf('The key "%s" is not supported.', $key));
+        }
+
+        return $outputs[$key];
+    }
+
+    protected function getFormat()
+    {
+        return 'array';
+    }
+
+    protected function hasDeserializer()
+    {
+        return false;
+    }
+
+}

--- a/Tests/Serializer/BaseSerializationTest.php
+++ b/Tests/Serializer/BaseSerializationTest.php
@@ -34,8 +34,10 @@ use JMS\SerializerBundle\Serializer\JsonDeserializationVisitor;
 use JMS\SerializerBundle\Serializer\JsonSerializationVisitor;
 use JMS\SerializerBundle\Serializer\Naming\CamelCaseNamingStrategy;
 use JMS\SerializerBundle\Serializer\Naming\SerializedNameAnnotationStrategy;
+use JMS\SerializerBundle\Serializer\Naming\PropertyNameNamingStrategy;
 use JMS\SerializerBundle\Serializer\Serializer;
 use JMS\SerializerBundle\Serializer\VisitorInterface;
+use JMS\SerializerBundle\Serializer\ArraySerializationVisitor;
 use JMS\SerializerBundle\Serializer\XmlDeserializationVisitor;
 use JMS\SerializerBundle\Serializer\XmlSerializationVisitor;
 use JMS\SerializerBundle\Serializer\YamlSerializationVisitor;
@@ -486,9 +488,10 @@ abstract class BaseSerializationTest extends \PHPUnit_Framework_TestCase
         $customDeserializationHandlers = $this->getDeserializationHandlers();
 
         $serializationVisitors = array(
-            'json' => new JsonSerializationVisitor($namingStrategy, $customSerializationHandlers),
-            'xml'  => new XmlSerializationVisitor($namingStrategy, $customSerializationHandlers),
-            'yml'  => new YamlSerializationVisitor($namingStrategy, $customSerializationHandlers),
+            'json'  => new JsonSerializationVisitor($namingStrategy, $customSerializationHandlers),
+            'xml'   => new XmlSerializationVisitor($namingStrategy, $customSerializationHandlers),
+            'yml'   => new YamlSerializationVisitor($namingStrategy, $customSerializationHandlers),
+            'array' => new ArraySerializationVisitor(new SerializedNameAnnotationStrategy(new PropertyNameNamingStrategy()), $customSerializationHandlers),
         );
         $deserializationVisitors = array(
             'json' => new JsonDeserializationVisitor($namingStrategy, $customDeserializationHandlers, $objectConstructor),
@@ -589,7 +592,7 @@ class Article implements SerializationHandlerInterface, DeserializationHandlerIn
             }
 
             $visitor->document->appendChild($visitor->document->createElement($this->element, $this->value));
-        } elseif ($visitor instanceof JsonSerializationVisitor) {
+        } elseif ($visitor instanceof JsonSerializationVisitor || $visitor instanceof ArraySerializationVisitor) {
             $visited = true;
 
             $visitor->setRoot(array($this->element => $this->value));
@@ -610,7 +613,7 @@ class Article implements SerializationHandlerInterface, DeserializationHandlerIn
             $visited = true;
 
             $this->element = $data->getName();
-            $this->value = (string)$data;
+            $this->value = (string) $data;
         } elseif ($visitor instanceof JsonDeserializationVisitor) {
             $visited = true;
 


### PR DESCRIPTION
Hi,
I know this sounds weird, but the idea is to use serializer bundle to convert any data to plain PHP associative arrays. 
The use case: 
We are using \SoapServer working with Doctrine entities. There's no way to implement anything like "@Accessor" with plain \SoapServer. So the idea is to write a wrapper class, which calls the methods of original class and converts the result to plain PHP associative arrays with all the features of SerializerBundle. 

Does it sound good?

P.S. I've already started working on this https://github.com/intellectsoft-uk/JMSSerializerBundle/tree/array-serializer
P.P.S. I will also need to implement PropertyNameNamingStrategy described in https://github.com/schmittjoh/JMSSerializerBundle/issues/49
