### PR TITLE
Allow access to Serializer's visitors getter

### DIFF
--- a/Serializer/LazyLoadingSerializer.php
+++ b/Serializer/LazyLoadingSerializer.php
@@ -29,7 +29,7 @@ class LazyLoadingSerializer extends Serializer
         $this->container = $container;
     }
 
-    protected function getDeserializationVisitor($format)
+    public function getDeserializationVisitor($format)
     {
         $visitor = parent::getDeserializationVisitor($format);
 
@@ -40,7 +40,7 @@ class LazyLoadingSerializer extends Serializer
         return $this->container->get($visitor);
     }
 
-    protected function getSerializationVisitor($format)
+    public function getSerializationVisitor($format)
     {
         $visitor = parent::getSerializationVisitor($format);
 

--- a/Serializer/Serializer.php
+++ b/Serializer/Serializer.php
@@ -105,7 +105,7 @@ class Serializer implements SerializerInterface
     /**
      * @return VisitorInterface
      */
-    protected function getDeserializationVisitor($format)
+    public function getDeserializationVisitor($format)
     {
         if (!isset($this->deserializationVisitors[$format])) {
             throw new UnsupportedFormatException(sprintf('Unsupported format "%s".', $format));
@@ -117,7 +117,7 @@ class Serializer implements SerializerInterface
     /**
      * @return VisitorInterface
      */
-    protected function getSerializationVisitor($format)
+    public function getSerializationVisitor($format)
     {
         if (!isset($this->serializationVisitors[$format])) {
             throw new UnsupportedFormatException(sprintf('Unsupported format "%s".', $format));


### PR DESCRIPTION
Since 1.0.x, I can no longer do

``` php
<?php

$container->get('jms_serializer.xml_serialization_visitor')->setDefaultRootName('a_root_name');
```

because `jms_serializer.xml_serialization_visitor` is now private.

With this PR I could just do

``` php
<?php

$container->get('serializer')->getSerializationVisitor('xml')->setDefaultRootName('a_root_name');
```
