### PR TITLE
Patch to deserialize null properties

### DIFF
--- a/Serializer/GenericDeserializationVisitor.php
+++ b/Serializer/GenericDeserializationVisitor.php
@@ -164,7 +164,7 @@ abstract class GenericDeserializationVisitor extends AbstractVisitor
     {
         $name = $this->namingStrategy->translateName($metadata);
 
-        if ( ! isset($data[$name])) {
+        if ( ! array_key_exists($name, $data)) {
             return;
         }
 
@@ -172,9 +172,14 @@ abstract class GenericDeserializationVisitor extends AbstractVisitor
             throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->reflection->class, $metadata->name));
         }
 
-        $v = $this->navigator->accept($data[$name], $metadata->type, $this);
-        if (null === $v) {
-            return;
+        $v = null;
+
+        if ($data[$name] !== null) {
+            $v = $this->navigator->accept($data[$name], $metadata->type, $this);
+
+            if (null === $v) {
+                return;
+            }
         }
 
         if (null === $metadata->setter) {

--- a/Serializer/GenericSerializationVisitor.php
+++ b/Serializer/GenericSerializationVisitor.php
@@ -134,7 +134,10 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
         $v = (null === $metadata->getter ? $metadata->reflection->getValue($data)
                 : $data->{$metadata->getter}());
 
-        $v = $this->navigator->accept($v, $metadata->type, $this);
+        if ($v !== null) {
+            $v = $this->navigator->accept($v, $metadata->type, $this);
+        }
+
         if (null === $v && !$this->shouldSerializeNull()) {
             return;
         }

--- a/Serializer/YamlSerializationVisitor.php
+++ b/Serializer/YamlSerializationVisitor.php
@@ -173,18 +173,21 @@ class YamlSerializationVisitor extends AbstractVisitor
 
         $count = $this->writer->changeCount;
 
-        if (null !== $v = $this->navigator->accept($v, $metadata->type, $this)) {
+        if ($v === null) {
+            $this->writer->rtrim(false)->writeln(' null');
+        } elseif (null !== $v = $this->navigator->accept($v, $metadata->type, $this)) {
             $this->writer
                 ->rtrim(false)
                 ->writeln(' '.$v)
             ;
-        } else if ($count === $this->writer->changeCount) {
+        } elseif ($count === $this->writer->changeCount) {
             $this->writer->revert();
         }
 
         if (!$metadata->inline) {
             $this->writer->outdent();
         }
+
         $this->revertCurrentMetadata();
     }
 

--- a/Tests/Fixtures/InitializedObjectConstructor.php
+++ b/Tests/Fixtures/InitializedObjectConstructor.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\SerializerBundle\Tests\Fixtures;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+use JMS\SerializerBundle\Metadata\ClassMetadata;
+
+use JMS\SerializerBundle\Serializer\Construction\ObjectConstructorInterface;
+use JMS\SerializerBundle\Serializer\VisitorInterface;
+
+use JMS\SerializerBundle\Tests\Fixtures\Author;
+
+class InitializedObjectConstructor implements ObjectConstructorInterface
+{
+    public function construct(VisitorInterface $visitor, ClassMetadata $metadata, $data, array $type)
+    {
+        $post = new \StdClass;
+        $post->title = 'This is a nice title.';
+        $post->author = new Author('Foo Bar');
+        $post->createdAt = new \DateTime('2011-07-30 00:00', new \DateTimeZone('UTC'));
+        $post->comments = new ArrayCollection();
+        $post->published = false;
+
+        return $post;
+    }
+}

--- a/Tests/Serializer/JsonSerializationTest.php
+++ b/Tests/Serializer/JsonSerializationTest.php
@@ -18,20 +18,15 @@
 
 namespace JMS\SerializerBundle\Tests\Serializer;
 
-use JMS\SerializerBundle\Serializer\VisitorInterface;
-
-use JMS\SerializerBundle\Serializer\GraphNavigator;
+use JMS\SerializerBundle\Exception\RuntimeException;
 
 use JMS\SerializerBundle\Serializer\EventDispatcher\EventSubscriberInterface;
-
 use JMS\SerializerBundle\Serializer\EventDispatcher\Event;
+use JMS\SerializerBundle\Serializer\GraphNavigator;
+use JMS\SerializerBundle\Serializer\VisitorInterface;
 
 use JMS\SerializerBundle\Tests\Fixtures\Author;
-
 use JMS\SerializerBundle\Tests\Fixtures\AuthorList;
-
-use JMS\SerializerBundle\Exception\RuntimeException;
-use JMS\SerializerBundle\Tests\Fixtures\SimpleObject;
 
 class JsonSerializationTest extends BaseSerializationTest
 {
@@ -56,6 +51,7 @@ class JsonSerializationTest extends BaseSerializationTest
             $outputs['array_objects'] = '[{"foo":"foo","moo":"bar","camel_case":"boo"},{"foo":"baz","moo":"boo","camel_case":"boo"}]';
             $outputs['array_mixed'] = '["foo",1,true,{"foo":"foo","moo":"bar","camel_case":"boo"},[1,3,true]]';
             $outputs['blog_post'] = '{"title":"This is a nice title.","created_at":"2011-07-30T00:00:00+0000","is_published":false,"comments":[{"author":{"full_name":"Foo Bar"},"text":"foo"}],"author":{"full_name":"Foo Bar"}}';
+            $outputs['blog_post_unauthored'] = '{"title":"This is a nice title.","created_at":"2011-07-30T00:00:00+0000","is_published":false,"comments":[],"author":null}';
             $outputs['price'] = '{"price":3}';
             $outputs['currency_aware_price'] = '{"currency":"EUR","amount":2.34}';
             $outputs['order'] = '{"cost":{"price":12.34}}';

--- a/Tests/Serializer/xml/blog_post_unauthored.xml
+++ b/Tests/Serializer/xml/blog_post_unauthored.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blog-post created_at="2011-07-30T00:00:00+0000" is_published="false">
+  <title><![CDATA[This is a nice title.]]></title>
+  <author xsi:nil="true"/>
+</blog-post>

--- a/Tests/Serializer/yml/blog_post_unauthored.yml
+++ b/Tests/Serializer/yml/blog_post_unauthored.yml
@@ -1,0 +1,4 @@
+title: 'This is a nice title.'
+created_at: '2011-07-30T00:00:00+0000'
+is_published: false
+author: null


### PR DESCRIPTION
use case:  when using the DoctrineObjectConstructor and an ORM entity has a property that can be either an object or null, a null would be ignored

/cc @guilhermeblanco
