### PR TITLE
DoctrineExclusionStrategy

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -26,6 +26,7 @@
         <parameter key="jms_serializer.unserialize_object_constructor.class">JMS\SerializerBundle\Serializer\Construction\UnserializeObjectConstructor</parameter>
 
         <parameter key="jms_serializer.version_exclusion_strategy.class">JMS\SerializerBundle\Serializer\Exclusion\VersionExclusionStrategy</parameter>
+        <parameter key="jms_serializer.doctrine_exclusion_strategy.class">JMS\SerializerBundle\Serializer\Exclusion\DoctrineExclusionStrategy</parameter>
 
         <parameter key="jms_serializer.serializer.class">JMS\SerializerBundle\Serializer\LazyLoadingSerializer</parameter>
 
@@ -124,7 +125,12 @@
                  class="%jms_serializer.version_exclusion_strategy.class%"
                  public="false"
                  abstract="true" />
-
+        <service id="jms_serializer.doctrine_exclusion_strategy"
+                 class="%jms_serializer.doctrine_exclusion_strategy.class%"
+                 public="true">
+            <argument type="service" id="doctrine" />
+        </service>
+        
         <!-- Naming Strategies -->
         <service id="jms_serializer.camel_case_naming_strategy" class="%jms_serializer.camel_case_naming_strategy.class%" public="false" />
         <service id="jms_serializer.serialized_name_annotation_strategy" class="%jms_serializer.serialized_name_annotation_strategy.class%" public="false">
@@ -156,6 +162,22 @@
             <tag name="jms_serializer.serializer" />
         </service>
         <service id="serializer" alias="jms_serializer.serializer" />
+        <service id="jms_serializer.doctrine_serializer" class="%jms_serializer.serializer.class%" public="false">
+            <argument type="service" id="jms_serializer.metadata_factory" />
+            <argument type="service" id="jms_serializer.handler_registry" />
+            <argument type="service" id="jms_serializer.doctrine_object_constructor" />
+            <argument type="service" id="jms_serializer.event_dispatcher" />
+            <argument>null</argument>
+            <argument type="collection" /><!-- Serialization Visitors -->
+            <argument type="collection" /><!-- Deserialization Visitors -->
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+            <call method="setExclusionStrategy">
+                <argument type="service" id="jms_serializer.doctrine_exclusion_strategy" />
+            </call>
+            <tag name="jms_serializer.serializer" />
+        </service>
 
         <!-- Twig Extension -->
         <service id="jms_serializer.twig_extension.serializer" class="%jms_serializer.twig_extension.class%" public="false">

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -130,7 +130,7 @@
                  public="true">
             <argument type="service" id="doctrine" />
         </service>
-        
+
         <!-- Naming Strategies -->
         <service id="jms_serializer.camel_case_naming_strategy" class="%jms_serializer.camel_case_naming_strategy.class%" public="false" />
         <service id="jms_serializer.serialized_name_annotation_strategy" class="%jms_serializer.serialized_name_annotation_strategy.class%" public="false">
@@ -162,17 +162,8 @@
             <tag name="jms_serializer.serializer" />
         </service>
         <service id="serializer" alias="jms_serializer.serializer" />
-        <service id="jms_serializer.doctrine_serializer" class="%jms_serializer.serializer.class%" public="false">
-            <argument type="service" id="jms_serializer.metadata_factory" />
-            <argument type="service" id="jms_serializer.handler_registry" />
-            <argument type="service" id="jms_serializer.doctrine_object_constructor" />
-            <argument type="service" id="jms_serializer.event_dispatcher" />
-            <argument>null</argument>
-            <argument type="collection" /><!-- Serialization Visitors -->
-            <argument type="collection" /><!-- Deserialization Visitors -->
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
+        <service id="jms_serializer.doctrine_serializer" parent="jms_serializer.serializer">
+            <argument index="2" type="service" id="jms_serializer.doctrine_object_constructor" />
             <call method="setExclusionStrategy">
                 <argument type="service" id="jms_serializer.doctrine_exclusion_strategy" />
             </call>

--- a/Serializer/Exclusion/ArrayExclusionStrategy.php
+++ b/Serializer/Exclusion/ArrayExclusionStrategy.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Copyright 2012 Vladimir Schmidt <morgen2009@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\SerializerBundle\Serializer\Exclusion;
+
+use JMS\SerializerBundle\Metadata\ClassMetadata;
+use JMS\SerializerBundle\Metadata\PropertyMetadata;
+use Doctrine\Common\Persistence\ManagerRegistry;
+
+/**
+ * Exclusion strategy for de-/serialization of properties specified in array.
+ *
+ * @author Vladimir Schmidt <morgen2009@gmail.com>
+ */
+class ArrayExclusionStrategy implements ExclusionStrategyInterface
+{
+    /**
+     * Array of properties, that will be de-/serialized
+     *
+     * @var array<string>
+     */
+    private $properties;
+
+    /**
+     * @param array<string> $properties
+     */
+    public function __construct(array $properties)
+    {
+        $this->properties = $properties;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function shouldSkipClass(ClassMetadata $metadata, $object = null)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function shouldSkipProperty(PropertyMetadata $property, $object = null)
+    {
+        return array_search($property->name, $this->properties) === false;
+    }
+}
+?>

--- a/Serializer/Exclusion/ArrayExclusionStrategy.php
+++ b/Serializer/Exclusion/ArrayExclusionStrategy.php
@@ -20,6 +20,7 @@ namespace JMS\SerializerBundle\Serializer\Exclusion;
 
 use JMS\SerializerBundle\Metadata\ClassMetadata;
 use JMS\SerializerBundle\Metadata\PropertyMetadata;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 /**
  * Exclusion strategy for de-/serialization of properties specified in array.
@@ -59,3 +60,4 @@ class ArrayExclusionStrategy implements ExclusionStrategyInterface
         return array_search($property->name, $this->properties) === false;
     }
 }
+?>

--- a/Serializer/Exclusion/ArrayExclusionStrategy.php
+++ b/Serializer/Exclusion/ArrayExclusionStrategy.php
@@ -20,7 +20,6 @@ namespace JMS\SerializerBundle\Serializer\Exclusion;
 
 use JMS\SerializerBundle\Metadata\ClassMetadata;
 use JMS\SerializerBundle\Metadata\PropertyMetadata;
-use Doctrine\Common\Persistence\ManagerRegistry;
 
 /**
  * Exclusion strategy for de-/serialization of properties specified in array.
@@ -60,4 +59,3 @@ class ArrayExclusionStrategy implements ExclusionStrategyInterface
         return array_search($property->name, $this->properties) === false;
     }
 }
-?>

--- a/Serializer/Exclusion/DoctrineExclusionStrategy.php
+++ b/Serializer/Exclusion/DoctrineExclusionStrategy.php
@@ -84,7 +84,7 @@ class DoctrineExclusionStrategy implements ExclusionStrategyInterface
      *
      * @param string $class
      * @param object $object
-     * @return ExclusionStrategyInterface | null
+     * @return null|ExclusionStrategyInterface
      * @note the return value null means that all properties will be de-/serialized
      */
     private function getObjectExclusionStrategy($class, $object)

--- a/Serializer/Exclusion/DoctrineExclusionStrategy.php
+++ b/Serializer/Exclusion/DoctrineExclusionStrategy.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * Copyright 2012 Vladimir Schmidt <morgen2009@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\SerializerBundle\Serializer\Exclusion;
+
+use JMS\SerializerBundle\Metadata\ClassMetadata;
+use JMS\SerializerBundle\Metadata\PropertyMetadata;
+use JMS\SerializerBundle\Exception\RuntimeException;
+use Doctrine\Common\Persistence\ManagerRegistry;
+
+/**
+ * Exclusion strategy for de-/serialization of Doctrine entities.
+ *
+ * @note Briefly, if the identificator is empty (or zero), then all
+ * properties of the entity will be traversed, otherwise only the identificator
+ *
+ * @author Vladimir Schmidt <morgen2009@gmail.com>
+ */
+class DoctrineExclusionStrategy implements ExclusionStrategyInterface
+{
+    /**
+     * @var Doctrine\Common\Persistence\ManagerRegistry
+     */
+    private $managerRegistry;
+
+    /**
+     * @param Doctrine\Common\Persistence\ManagerRegistry $managerRegistry
+     */
+    public function __construct(ManagerRegistry $managerRegistry)
+    {
+        $this->managerRegistry = $managerRegistry;
+    }
+
+    /**
+     * Exception classes, those properties will be serialized without
+     * taking into account the identificator
+     *
+     * @var array<string>
+     */
+    private $exposeClasses = array();
+
+    /**
+     * Add class into the exception list
+     *
+     * @param string  $className class name without leading "\" (like get_class() returns)
+     * @param boolean $clear remove previosly added classes
+     */
+    public function setExposeClass($className, $clear = false)
+    {
+        if ($clear) $this->exposeClasses = array();
+        if (strlen($className) > 0) $this->exposeClasses[$className] = true;
+    }
+
+    /**
+     * Check if class is in the exception list
+     *
+     * @param string $className
+     */
+    public function isExposeClass($className)
+    {
+        return isset($this->exposeClasses[$className]);
+    }
+
+    /**
+     * Get array of properties for given object to de-/serialize
+     *
+     * @param string $class
+     * @param object $object
+     * @return array<string> | null The value null means all object properties
+     */
+    public function getPassProperties($class, $object)
+    {
+        if ($this->isExposeClass($class) || $object == null) {
+            return false;
+        }
+
+        // Locate possible ObjectManager
+        $objectManager = $this->managerRegistry->getManagerForClass($class);
+
+        if (!$objectManager) {
+            return false;
+        }
+
+        // Locate possible ClassMetadata
+        $classMetadataFactory = $objectManager->getMetadataFactory();
+
+        if ($classMetadataFactory->isTransient($class)) {
+            return false;
+        }
+
+        // Entity update, load it from database
+        $classMetadata         = $objectManager->getClassMetadata($class);
+        $identifierList        = $classMetadata->getIdentifierFieldNames();
+        $identifierValuesList  = $classMetadata->getIdentifierValues($object);
+        $missingIdentifierList = array_filter(
+            $identifierList,
+            function ($identifier) use ($identifierValuesList)
+            {
+                return !isset($identifierValuesList[$identifier]);
+            }
+        );
+
+        if (count($missingIdentifierList) > 0) {
+            return false;
+        } else {
+            return $identifierList;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    function shouldSkipClass(ClassMetadata $metadata, $object = null)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    function shouldSkipProperty(PropertyMetadata $property, $object = null)
+    {
+        $passList = $this->getPassProperties($property->class, $object);
+        if ($passList == false) {
+            return false;
+        } else {
+            return array_search($property->name, $passList) === false;
+        }
+    }
+}
+
+?>

--- a/Serializer/Exclusion/DoctrineExclusionStrategy.php
+++ b/Serializer/Exclusion/DoctrineExclusionStrategy.php
@@ -133,8 +133,7 @@ class DoctrineExclusionStrategy implements ExclusionStrategyInterface
         $strategy = $this->getObjectExclusionStrategy($property->class, $object);
         if ($strategy === null) {
             return false;
-        } else {
-            return $strategy->shouldSkipProperty($property, $object);
         }
+        return $strategy->shouldSkipProperty($property, $object);
     }
 }

--- a/Serializer/Exclusion/DoctrineExclusionStrategy.php
+++ b/Serializer/Exclusion/DoctrineExclusionStrategy.php
@@ -84,7 +84,7 @@ class DoctrineExclusionStrategy implements ExclusionStrategyInterface
      *
      * @param string $class
      * @param object $object
-     * @return null|ExclusionStrategyInterface
+     * @return ExclusionStrategyInterface | null
      * @note the return value null means that all properties will be de-/serialized
      */
     private function getObjectExclusionStrategy($class, $object)

--- a/Serializer/Exclusion/DoctrineExclusionStrategy.php
+++ b/Serializer/Exclusion/DoctrineExclusionStrategy.php
@@ -33,7 +33,7 @@ use Doctrine\Common\Persistence\ManagerRegistry;
 class DoctrineExclusionStrategy implements ExclusionStrategyInterface
 {
     /**
-     * @var Doctrine\Common\Persistence\ManagerRegistry
+     * @var ManagerRegistry
      */
     private $managerRegistry;
 

--- a/Serializer/Exclusion/DoctrineExclusionStrategy.php
+++ b/Serializer/Exclusion/DoctrineExclusionStrategy.php
@@ -57,7 +57,7 @@ class DoctrineExclusionStrategy implements ExclusionStrategyInterface
      * Add class into the exception list
      *
      * @param string  $className class name without leading "\" (like get_class() returns)
-     * @param boolean $clear remove previosly added classes
+     * @param boolean $clear remove previously added classes
      */
     public function addExposedClass($className, $clear = false)
     {

--- a/Serializer/Exclusion/DoctrineExclusionStrategy.php
+++ b/Serializer/Exclusion/DoctrineExclusionStrategy.php
@@ -20,7 +20,6 @@ namespace JMS\SerializerBundle\Serializer\Exclusion;
 
 use JMS\SerializerBundle\Metadata\ClassMetadata;
 use JMS\SerializerBundle\Metadata\PropertyMetadata;
-use JMS\SerializerBundle\Exception\RuntimeException;
 use Doctrine\Common\Persistence\ManagerRegistry;
 
 /**
@@ -39,7 +38,7 @@ class DoctrineExclusionStrategy implements ExclusionStrategyInterface
     private $managerRegistry;
 
     /**
-     * @param Doctrine\Common\Persistence\ManagerRegistry $managerRegistry
+     * @param ManagerRegistry $managerRegistry
      */
     public function __construct(ManagerRegistry $managerRegistry)
     {
@@ -62,8 +61,12 @@ class DoctrineExclusionStrategy implements ExclusionStrategyInterface
      */
     public function setExposeClass($className, $clear = false)
     {
-        if ($clear) $this->exposeClasses = array();
-        if (strlen($className) > 0) $this->exposeClasses[$className] = true;
+        if ($clear) {
+            $this->exposeClasses = array();
+        }
+        if (strlen($className) > 0) {
+            $this->exposeClasses[$className] = true;
+        }
     }
 
     /**
@@ -109,8 +112,7 @@ class DoctrineExclusionStrategy implements ExclusionStrategyInterface
         $identifierValuesList  = $classMetadata->getIdentifierValues($object);
         $missingIdentifierList = array_filter(
             $identifierList,
-            function ($identifier) use ($identifierValuesList)
-            {
+            function ($identifier) use ($identifierValuesList) {
                 return !isset($identifierValuesList[$identifier]);
             }
         );
@@ -143,5 +145,4 @@ class DoctrineExclusionStrategy implements ExclusionStrategyInterface
         }
     }
 }
-
 ?>

--- a/Serializer/GraphNavigator.php
+++ b/Serializer/GraphNavigator.php
@@ -95,11 +95,6 @@ final class GraphNavigator
      */
     public function accept($data, array $type = null, VisitorInterface $visitor)
     {
-        // if data is null, then stop to traverse
-        if (null === $data) {
-            return;
-        }
-
         // If the type was not given, we infer the most specific type from the
         // input data in serialization mode.
         if (null === $type) {
@@ -155,6 +150,11 @@ final class GraphNavigator
                         return null;
                     }
                     $this->visiting->attach($data);
+                }
+
+                // if data is  null, then stop to traverse
+                if (null === $data) {
+                    return;
                 }
 
                 // First, try whether a custom handler exists for the given type. This is done

--- a/Serializer/GraphNavigator.php
+++ b/Serializer/GraphNavigator.php
@@ -95,6 +95,11 @@ final class GraphNavigator
      */
     public function accept($data, array $type = null, VisitorInterface $visitor)
     {
+        // if data is null, then stop to traverse
+        if (null === $data) {
+            return;
+        }
+
         // If the type was not given, we infer the most specific type from the
         // input data in serialization mode.
         if (null === $type) {


### PR DESCRIPTION
DoctrineExclusionStrategy means
- serialization: if entity's id is not null (or not zero), then serialize only the identificator
- deserialization: DoctrineObjectConstructor restores entity from DB using identificator (already implemented)

Also I fixed a bit GraphNavigator.php in the case, if the element is null (use case is some properties of entity are null or omited)
