### PR TITLE
Return null when a property which should be an object is null

### DIFF
--- a/Serializer/GraphNavigator.php
+++ b/Serializer/GraphNavigator.php
@@ -194,6 +194,10 @@ final class GraphNavigator
                     $object = $this->objectConstructor->construct($visitor, $metadata, $data, $type);
                 }
 
+                if ($isSerializing && null === $object) {
+                    return null;
+                }
+
                 if (isset($metadata->handlerCallbacks[$this->direction][$this->format])) {
                     $rs = $object->{$metadata->handlerCallbacks[$this->direction][$this->format]}($visitor, $isSerializing ? null : $data);
                     $this->afterVisitingObject($visitor, $metadata, $object, $type);


### PR DESCRIPTION
I have a class like this and the property $object is nullable.

``` php
namespace MyNamespace\Whatever;

use JMS\SerializerBundle\Annotation as JMS;

class TestClass
{
    /**
     * @JMS\Type("MyNamespace\Whatever\AnotherClass")
     */
    public $object = null;

    //[...]
}
```

When I try to so serialize the object I get an exception:

```
ReflectionProperty::getValue() expects parameter 1 to be object, null given in ...\vendor\jms\serializer-bundle\JMS\SerializerBundle\Serializer\GenericSerializationVisitor.php line 136
```

This is because the GraphNavigatior tries to visit properties, which are annotated with a custom class, even if they are null. The pull request will fix this problem.
