### PR TITLE
GenericSerializationVisitor::addData is now more powerful

### DIFF
--- a/Serializer/GenericSerializationVisitor.php
+++ b/Serializer/GenericSerializationVisitor.php
@@ -153,17 +153,23 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
     /**
      * Allows you to add additional data to the current object/root element.
      *
-     * @param string $key
-     * @param scalar|array $value This value must either be a regular scalar, or an array.
-     *                            It must not contain any objects anymore.
+     * @param string       $key
+     * @param scalar|array $value   This value must either be a regular scalar, or an array.
+     *                              It must not contain any objects anymore.
+     * @param boolean      $replace Whether the user intended to replace existing data
      */
-    public function addData($key, $value)
+    public function addData($key, $value, $replace = false)
     {
-        if (isset($this->data[$key])) {
+        if (!$replace && isset($this->data[$key])) {
             throw new \InvalidArgumentException(sprintf('There is already data for "%s".', $key));
         }
 
         $this->data[$key] = $value;
+    }
+
+    public function getData()
+    {
+        return $this->data;
     }
 
     public function getRoot()

--- a/Tests/Serializer/JsonSerializationTest.php
+++ b/Tests/Serializer/JsonSerializationTest.php
@@ -116,10 +116,12 @@ class LinkAddingSubscriber implements EventSubscriberInterface
     {
         $author = $event->getObject();
 
-        $event->getVisitor()->addData('_links', array(
+        $links = array(
             'details' => 'http://foo.bar/details/'.$author->getName(),
             'comments' => 'http://foo.bar/details/'.$author->getName().'/comments',
-        ));
+        );
+        $event->getVisitor()->addData('_links', $links);
+        $event->getVisitor()->addData('_links', $links, true);
     }
 
     public static function getSubscribedEvents()


### PR DESCRIPTION
Hi,

When serializing inlined data, this is required, because an event subscriber may add links multiple times (for the wrapper object, and for the inline object ...).
