### PR TITLE
correct name of date handler class

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -42,7 +42,7 @@
         
         <parameter key="jms_serializer.handler_registry.class">JMS\Serializer\Handler\LazyHandlerRegistry</parameter>
 
-        <parameter key="jms_serializer.datetime_handler.class">JMS\Serializer\Handler\DateTimeHandler</parameter>
+        <parameter key="jms_serializer.datetime_handler.class">JMS\Serializer\Handler\DateHandler</parameter>
         <parameter key="jms_serializer.array_collection_handler.class">JMS\Serializer\Handler\ArrayCollectionHandler</parameter>
         <parameter key="jms_serializer.form_error_handler.class">JMS\Serializer\Handler\FormErrorHandler</parameter>
         <parameter key="jms_serializer.constraint_violation_handler.class">JMS\Serializer\Handler\ConstraintViolationHandler</parameter>


### PR DESCRIPTION
The latest commit to serializer renamed the DateHandler class, breaking this bundle.

https://github.com/schmittjoh/serializer/commit/8208d71dd8e64f13fc1930b922c7957683009aaf
