### PR TITLE
fix handler compiler pass

### DIFF
--- a/DependencyInjection/Compiler/CustomHandlersPass.php
+++ b/DependencyInjection/Compiler/CustomHandlersPass.php
@@ -29,7 +29,7 @@ class CustomHandlersPass implements CompilerPassInterface
 
                 foreach ($directions as $direction) {
                     $method = isset($attrs['method']) ? $attrs['method'] : HandlerRegistry::getDefaultMethod($direction, $attrs['type'], $attrs['format']);
-                    $handlers[$direction][$attrs['type']][$attrs['format']] = array($id, $method);
+                    $handlers[$direction][$attrs['type']][$attrs['format']] = array($container->getDefinition($id), $method);
                 }
             }
         }
@@ -53,7 +53,7 @@ class CustomHandlersPass implements CompilerPassInterface
 
                 foreach ($directions as $direction) {
                     $method = isset($methodData['method']) ? $methodData['method'] : HandlerRegistry::getDefaultMethod($direction, $methodData['type'], $methodData['format']);
-                    $handlers[$direction][$methodData['type']][$methodData['format']] = array($id, $method);
+                    $handlers[$direction][$methodData['type']][$methodData['format']] = array($container->getDefinition($id), $method);
                 }
             }
         }


### PR DESCRIPTION
I was getting this error:

```
[{"message":"Warning: call_user_func() expects parameter 1 to be a valid callback, class 'pc_product_image_serializer' not found in \/home\/bart\/workspace\/macedes.com\/vendor\/jms\/serializer-bundle\/JMS\/SerializerBundle\/Serializer\/GraphNavigator.php line 159","class":"ErrorException","trace":....]
```

I was able fix it using the change in this PR, yet i find it strange that noone else ever encountered this... Is this fix legit, or am I actually taking a wrong approach here?
