### PR TITLE
Fixed the composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.3.2",
         "jms/serializer": "0.11.*",
         "symfony/framework-bundle": ">=2.1,<3.0-dev",
-        "jms/di-extra-bundle": ">=1.3"
+        "jms/di-extra-bundle": "~1.3@alpha"
     },
     "require-dev": {
         "symfony/yaml": "*",


### PR DESCRIPTION
This adds an upper bound on the JMSDiExtraBundle and let the
1.3.0-alpha version of JMSDiExtraBundle match the requirement

This should fix #274
