### PR TITLE
Ensure ORM is available 

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -104,7 +104,7 @@ class Configuration implements ConfigurationInterface
                     ->booleanNode('auto_detection')->defaultTrue()->end()
                     ->booleanNode('infer_types_from_doctrine_metadata')
                         ->info('Infers type information from Doctrine metadata if no explicit type has been defined for a property.')
-                        ->defaultTrue()
+                        ->defaultValue(class_exists('Doctrine\ORM\Version'))
                     ->end()
                     ->arrayNode('directories')
                         ->prototype('array')


### PR DESCRIPTION
Update configuration to have default value for infer_types_from_doctrine_metadata be based off if the ORM version class exists since the Doctrine bundle may exist without using the ORM as it's assumed to be available in the JMSSerializerExtension class
