### PR TITLE
Documentation Fix: When registering an event listener, you have to additional attribute "cl...

### DIFF
--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -29,7 +29,7 @@ The semantics are mainly the same as registering a regular Symfony2 event listen
 except that you can specify some additional attributes:
 
 - *format*: The format that you want to listen to; defaults to all formats.
-- *type*: The type name that you want to listen to; defaults to all types.
+- *class*: The type name that you want to listen to; defaults to all types.
 - *direction*: The direction (serialization, or deserialization); defaults to both.
 
 .. note ::


### PR DESCRIPTION
...ass" instead of "type".

Using "type" has no effect. It turns out it is supposed to be 'class'. Also figured it here - http://stackoverflow.com/questions/15007281/add-extra-fields-using-jms-serializer-bundle
