### PR TITLE
Fix #270 - Allow changing naming strategy and disabling annotation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -78,10 +78,20 @@ class Configuration implements ConfigurationInterface
             ->arrayNode('property_naming')
                 ->addDefaultsIfNotSet()
                 ->children()
-                    ->scalarNode('id')->cannotBeEmpty()->end()
-                    ->scalarNode('separator')->defaultValue('_')->end()
-                    ->booleanNode('lower_case')->defaultTrue()->end()
+                    ->scalarNode('strategy')->defaultValue('camel_case')->end()
+                    ->arrayNode('camel_case')
+                        ->addDefaultsIfNotSet()
+                        ->children()
+                            ->scalarNode('separator')->defaultValue('_')->end()
+                            ->booleanNode('lower_case')->defaultTrue()->end()
+                        ->end()
+                    ->end()
+                    ->booleanNode('enable_annotation')->defaultTrue()->end()
                     ->booleanNode('enable_cache')->defaultTrue()->end()
+
+                    // For BC we include the old nodes
+                    ->scalarNode('separator')->defaultNull()->end()
+                    ->booleanNode('lower_case')->defaultNull()->end()
                 ->end()
             ->end()
         ;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -89,9 +89,29 @@ class Configuration implements ConfigurationInterface
                     ->booleanNode('enable_annotation')->defaultTrue()->end()
                     ->booleanNode('enable_cache')->defaultTrue()->end()
 
-                    // For BC we include the old nodes
-                    ->scalarNode('separator')->defaultNull()->end()
-                    ->booleanNode('lower_case')->defaultNull()->end()
+                    // For BC we include the old nodes and convert them in beforeNormalization()
+                    ->scalarNode('separator')->end()
+                    ->booleanNode('lower_case')->end()
+                ->end()
+                ->beforeNormalization()
+                    ->ifTrue(function ($v) {
+                        return
+                            ( !isset($v['camel_case']) || empty($v['camel_case']) )
+                            &&
+                            ( isset($v['separator']) || isset($v['lower_case']) )
+                        ;
+                    })
+                    ->then(function ($v) {
+                        if (isset($v['separator'])) {
+                            $v['camel_case']['separator'] = $v['separator'];
+                        }
+                        if (isset($v['lower_case'])) {
+                            $v['camel_case']['lower_case'] = $v['lower_case'];
+                        }
+                        unset($v['lower_case'], $v['separator']);
+
+                        return $v;
+                    })
                 ->end()
             ->end()
         ;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -88,25 +88,19 @@ class Configuration implements ConfigurationInterface
                     ->end()
                     ->booleanNode('enable_annotation')->defaultTrue()->end()
                     ->booleanNode('enable_cache')->defaultTrue()->end()
-
-                    // For BC we include the old nodes and convert them in beforeNormalization()
-                    ->scalarNode('separator')->end()
-                    ->booleanNode('lower_case')->end()
                 ->end()
                 ->beforeNormalization()
                     ->ifTrue(function ($v) {
-                        return
-                            ( !isset($v['camel_case']) || empty($v['camel_case']) )
-                            &&
-                            ( isset($v['separator']) || isset($v['lower_case']) )
-                        ;
+                        return isset($v['separator']) || isset($v['lower_case']);
                     })
                     ->then(function ($v) {
-                        if (isset($v['separator'])) {
-                            $v['camel_case']['separator'] = $v['separator'];
-                        }
-                        if (isset($v['lower_case'])) {
-                            $v['camel_case']['lower_case'] = $v['lower_case'];
+                        if (!isset($v['camel_case']) || empty($v['camel_case'])) {
+                            if (isset($v['separator'])) {
+                                $v['camel_case']['separator'] = $v['separator'];
+                            }
+                            if (isset($v['lower_case'])) {
+                                $v['camel_case']['lower_case'] = $v['lower_case'];
+                            }
                         }
                         unset($v['lower_case'], $v['separator']);
 

--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -114,11 +114,11 @@ class JMSSerializerExtension extends ConfigurableExtension
         $container->setParameter('jms_serializer.xml_deserialization_visitor.doctype_whitelist', $config['visitors']['xml']['doctype_whitelist']);
         $container->setParameter('jms_serializer.json_serialization_visitor.options', $config['visitors']['json']['options']);
 
-        if ( ! $config['enable_short_alias']) {
+        if (! $config['enable_short_alias']) {
             $container->removeAlias('serializer');
         }
 
-        if ( ! $container->getParameter('kernel.debug')) {
+        if (! $container->getParameter('kernel.debug')) {
             $container->removeDefinition('jms_serializer.stopwatch_subscriber');
         }
     }
@@ -134,14 +134,6 @@ class JMSSerializerExtension extends ConfigurableExtension
      */
     private function loadPropertyNamingStrategy(array $config, ContainerBuilder $container)
     {
-        // For BC we copy the old config nodes to the new ones
-        if (is_string($config['property_naming']['separator'])) {
-            $config['property_naming']['camel_case']['separator'] = $config['property_naming']['separator'];
-        }
-        if (is_bool($config['property_naming']['lower_case'])) {
-            $config['property_naming']['camel_case']['lower_case'] = $config['property_naming']['lower_case'];
-        }
-
         $container
             ->getDefinition('jms_serializer.camel_case_naming_strategy')
             ->addArgument($config['property_naming']['camel_case']['separator'])
@@ -156,7 +148,7 @@ class JMSSerializerExtension extends ConfigurableExtension
         if ($config['property_naming']['enable_annotation']) {
             $container
                 ->getDefinition('jms_serializer.serialized_name_annotation_strategy')
-                ->addArgument(new Reference((string)$container->getAlias('jms_serializer.naming_strategy')));
+                ->addArgument(new Reference($strategy));
             $container->setAlias('jms_serializer.naming_strategy', 'jms_serializer.serialized_name_annotation_strategy');
         }
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -23,6 +23,7 @@
         <parameter key="jms_serializer.camel_case_naming_strategy.class">JMS\Serializer\Naming\CamelCaseNamingStrategy</parameter>
         <parameter key="jms_serializer.serialized_name_annotation_strategy.class">JMS\Serializer\Naming\SerializedNameAnnotationStrategy</parameter>
         <parameter key="jms_serializer.cache_naming_strategy.class">JMS\Serializer\Naming\CacheNamingStrategy</parameter>
+        <parameter key="jms_serializer.identical_property_naming_strategy.class">JMS\Serializer\Naming\IdenticalPropertyNamingStrategy</parameter>
 
         <parameter key="jms_serializer.doctrine_object_constructor.class">JMS\Serializer\Construction\DoctrineObjectConstructor</parameter>
         <parameter key="jms_serializer.unserialize_object_constructor.class">JMS\Serializer\Construction\UnserializeObjectConstructor</parameter>
@@ -41,7 +42,7 @@
         <parameter key="jms_serializer.xml_deserialization_visitor.class">JMS\Serializer\XmlDeserializationVisitor</parameter>
         <parameter key="jms_serializer.xml_deserialization_visitor.doctype_whitelist" type="collection"></parameter>
         <parameter key="jms_serializer.yaml_serialization_visitor.class">JMS\Serializer\YamlSerializationVisitor</parameter>
-        
+
         <parameter key="jms_serializer.handler_registry.class">JMS\Serializer\Handler\LazyHandlerRegistry</parameter>
 
         <parameter key="jms_serializer.datetime_handler.class">JMS\Serializer\Handler\DateHandler</parameter>
@@ -65,7 +66,7 @@
             <tag name="jms_serializer.event_subscriber" />
             <argument type="service" id="debug.stopwatch" />
         </service>
-        
+
         <!-- Handlers -->
         <service id="jms_serializer.handler_registry" class="%jms_serializer.handler_registry.class%">
             <argument type="service" id="service_container" />
@@ -86,7 +87,7 @@
         <service id="jms_serializer.constraint_violation_handler" class="%jms_serializer.constraint_violation_handler.class%">
             <tag name="jms_serializer.subscribing_handler" />
         </service>
-            
+
         <!-- Metadata Drivers -->
         <service id="jms_serializer.metadata.file_locator" class="%jms_serializer.metadata.file_locator.class%" public="false">
             <argument type="collection" /><!-- Namespace Prefixes mapping to Directories -->
@@ -146,12 +147,12 @@
                  abstract="true" />
 
         <!-- Naming Strategies -->
-        <service id="jms_serializer.camel_case_naming_strategy" class="%jms_serializer.camel_case_naming_strategy.class%" public="false" />
-        <service id="jms_serializer.serialized_name_annotation_strategy" class="%jms_serializer.serialized_name_annotation_strategy.class%" public="false">
-            <argument type="service" id="jms_serializer.camel_case_naming_strategy" />
-        </service>
         <service id="jms_serializer.cache_naming_strategy" class="%jms_serializer.cache_naming_strategy.class%" public="false" />
-        <service id="jms_serializer.naming_strategy" alias="jms_serializer.serialized_name_annotation_strategy" public="false" />
+        <service id="jms_serializer.camel_case_naming_strategy" class="%jms_serializer.camel_case_naming_strategy.class%" public="false" />
+        <service id="jms_serializer.identical_property_naming_strategy" class="%jms_serializer.identical_property_naming_strategy.class%" public="false" />
+        <service id="jms_serializer.serialized_name_annotation_strategy" class="%jms_serializer.serialized_name_annotation_strategy.class%" public="false" />
+
+        <service id="jms_serializer.naming_strategy" alias="jms_serializer.camel_case_naming_strategy" public="false" />
 
         <!-- Object Constructors -->
         <service id="jms_serializer.doctrine_object_constructor" class="%jms_serializer.doctrine_object_constructor.class%" public="false">

--- a/Tests/DependencyInjection/JMSSerializerExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSerializerExtensionTest.php
@@ -211,6 +211,60 @@ class JMSSerializerExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayNotHasKey('camel_case', $actual);
     }
 
+    public function testOldConfigForCamelCasePropertyNaming()
+    {
+        $config = array(
+            'property_naming' => array(
+                'separator' => '-',
+                'lower_case' => false,
+            )
+        );
+        $container = $this->getContainerForConfig(array($config));
+        $simpleObject = new SimpleObject('foo', 'bar');
+        $serializer = $container->get('serializer');
+        $actual = json_decode($serializer->serialize($simpleObject, 'json'), true);
+
+        $this->assertArrayHasKey('Camel-Case', $actual);
+    }
+
+    public function testEmptyNewConfigStillTriggersBCLayer()
+    {
+        $config = array(
+            'property_naming' => array(
+                'camel_case' => array (),
+                'separator' => '-',
+                'lower_case' => false,
+            )
+        );
+        $container = $this->getContainerForConfig(array($config));
+        $simpleObject = new SimpleObject('foo', 'bar');
+        $serializer = $container->get('serializer');
+        $actual = json_decode($serializer->serialize($simpleObject, 'json'), true);
+
+        $this->assertArrayHasKey('Camel-Case', $actual);
+    }
+
+    public function testNewConfigHasPrecedenceOverOldConfigForCamelCasePropertyNaming()
+    {
+        $config = array(
+            'property_naming' => array(
+                'camel_case' => array (
+                    'separator' => '.',
+                    'lower_case' => true,
+                ),
+                'separator' => '-',
+                'lower_case' => false,
+            )
+        );
+        $container = $this->getContainerForConfig(array($config));
+        $simpleObject = new SimpleObject('foo', 'bar');
+        $serializer = $container->get('serializer');
+        $actual = json_decode($serializer->serialize($simpleObject, 'json'), true);
+
+        $this->assertArrayHasKey('camel.case', $actual);
+        $this->assertArrayNotHasKey('Camel-Case', $actual);
+    }
+
     public function testDisablingAnotationNamingStrategy()
     {
         $config = array(

--- a/Tests/DependencyInjection/JMSSerializerExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSerializerExtensionTest.php
@@ -182,4 +182,48 @@ class JMSSerializerExtensionTest extends \PHPUnit_Framework_TestCase
 
         return $container;
     }
+
+    public function testDefaultPropertyNamingStrategy()
+    {
+        $config = array();
+        $container = $this->getContainerForConfig(array($config));
+        $simpleObject = new SimpleObject('foo', 'bar');
+        $serializer = $container->get('serializer');
+        $actual = $serializer->serialize($simpleObject, 'json');
+
+        $this->assertEquals(json_encode(array('foo'=>'foo','moo'=>'bar','camel_case'=>'boo')), $actual);
+    }
+
+    public function testIdenticalPropertyNamingStrategy()
+    {
+        $config = array(
+            'property_naming' => array(
+                'strategy' => 'identical',
+                'enable_annotation' => false
+            )
+        );
+        $container = $this->getContainerForConfig(array($config));
+        $simpleObject = new SimpleObject('foo', 'bar');
+        $serializer = $container->get('serializer');
+        $actual = json_decode($serializer->serialize($simpleObject, 'json'), true);
+
+        $this->assertArrayHasKey('camelCase', $actual);
+        $this->assertArrayNotHasKey('camel_case', $actual);
+    }
+
+    public function testDisablingAnotationNamingStrategy()
+    {
+        $config = array(
+            'property_naming' => array(
+                'enable_annotation' => false
+            )
+        );
+        $container = $this->getContainerForConfig(array($config));
+        $simpleObject = new SimpleObject('foo', 'bar');
+        $serializer = $container->get('serializer');
+        $actual = json_decode($serializer->serialize($simpleObject, 'json'), true);
+
+        $this->assertArrayHasKey('bar', $actual);
+        $this->assertArrayNotHasKey('moo', $actual);
+    }
 }


### PR DESCRIPTION
I implement the config as commended by @schmittjoh in #270

This PR is targeted to be completely backward compatible, so the old configuration will still work and  the defaults are still the same for annotation,cache and camel_case.

Also added some tests for the configuration. (one copied from #270)

What do you think about that?

I will also update the documentation if we agree on this configuration.
