### PR TITLE
if set to false in config.yml parameter is not set

### DIFF
--- a/DependencyInjection/Compiler/DoctrinePass.php
+++ b/DependencyInjection/Compiler/DoctrinePass.php
@@ -10,7 +10,7 @@ class DoctrinePass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (!$container->getParameter('jms_serializer.infer_types_from_doctrine_metadata')) {
+        if (!$container->hasParameter('jms_serializer.infer_types_from_doctrine_metadata')) {
             return;
         }
 


### PR DESCRIPTION
app/console cache:clear fails with

[Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException]  
  You have requested a non-existent parameter "jms_serializer.infer_types_from_doctrine_metadata".                                                         

when you have 

jms_serializer:
    metadata:
        infer_types_from_doctrine_metadata: false

in you config.yml
