### PR TITLE
fix chaining of metadata driver and object constructor

### DIFF
--- a/DependencyInjection/Compiler/DoctrinePass.php
+++ b/DependencyInjection/Compiler/DoctrinePass.php
@@ -30,25 +30,26 @@ class DoctrinePass implements CompilerPassInterface
         }
 
         $serviceTemplates = array(
-            'jms_serializer.metadata_driver' => 'jms_serializer.metadata.%s_type_driver',
-            'jms_serializer.object_constructor' => 'jms_serializer.%s_object_constructor',
+            'jms_serializer.metadata_driver' => array('template' => 'jms_serializer.metadata.%s_type_driver', 'position' => 0),
+            'jms_serializer.object_constructor' => array('template' => 'jms_serializer.%s_object_constructor', 'position' => 1)
         );
 
         $registry = array_pop($registries);
         $previousId = array();
-        foreach ($serviceTemplates as $service => $serviceTemplate) {
-            $previousId[$service] = sprintf($serviceTemplate, $registry);
-            $container->setAlias($service, $previousId[$service]);
+        foreach ($serviceTemplates as $serviceName => $service) {
+            $previousId[$serviceName] = sprintf($service['template'], $registry);
+            $container->setAlias($serviceName, $previousId[$serviceName]);
         }
 
         foreach ($registries as $registry) {
-            foreach ($serviceTemplates as $service => $serviceTemplate) {
-                $id = sprintf($serviceTemplate, $registry);
+            foreach ($serviceTemplates as $serviceName => $service) {
+                $id = sprintf($service['template'], $registry);
                 $container
                     ->getDefinition($id)
-                    ->replaceArgument(0, new Reference($previousId[$service]))
+                    ->replaceArgument($service['position'], new Reference($previousId[$serviceName]))
                 ;
-                $previousId[$service] = $id;
+                $previousId[$serviceName] = $id;
+                $container->setAlias($serviceName, $previousId[$serviceName]);
             }
         }
     }

--- a/JMSSerializerBundle.php
+++ b/JMSSerializerBundle.php
@@ -45,7 +45,7 @@ class JMSSerializerBundle extends Bundle
 
         $builder->addCompilerPass(new RegisterEventListenersAndSubscribersPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $builder->addCompilerPass(new CustomHandlersPass(), PassConfig::TYPE_BEFORE_REMOVING);
-        $builder->addCompilerPass(new DoctrinePass(), PassConfig::TYPE_BEFORE_REMOVING);
+        $builder->addCompilerPass(new DoctrinePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION);
     }
 
     private function getServiceMapPass($tagName, $keyAttributeName, $callable)


### PR DESCRIPTION
This change properly creates the object constructors and metadata drivers for doctrine and doctrine_phpcr and sets the aliases the right way while this is still possible.

Fixes https://github.com/schmittjoh/JMSSerializerBundle/issues/389
