### PR TITLE
[Doc - Configuration] Fix yaml code-block

### DIFF
--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -72,12 +72,12 @@ default constructor uses the `unserialize` function to construct objects. Other
 constructors are configured as services. You can set the constructor by changing 
 the service alias:
 
-```yaml
-services:
-    jms_serializer.object_constructor:
-        alias: jms_serializer.doctrine_object_constructor
-        public: false
-```
+.. code-block :: yaml
+
+    services:
+        jms_serializer.object_constructor:
+            alias: jms_serializer.doctrine_object_constructor
+            public: false
 
 Extension Reference
 -------------------


### PR DESCRIPTION
Hello,

Juste a little fix in the documentation ```yaml that wasn't interpreted has been changed for .. code-block.

Regards,
Peekmo
