### PR TITLE
Metadata directories config is assoc array

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -108,6 +108,7 @@ class Configuration implements ConfigurationInterface
                         ->defaultTrue()
                     ->end()
                     ->arrayNode('directories')
+                        ->useAttributeAsKey('name')
                         ->prototype('array')
                             ->children()
                                 ->scalarNode('path')->isRequired()->end()


### PR DESCRIPTION
This without this change it blocks adding `directories` via `PrependExtensionInterface`.
