### PR TITLE
Applied standard installation template

### DIFF
--- a/Resources/doc/installation.rst
+++ b/Resources/doc/installation.rst
@@ -1,104 +1,41 @@
 Installation
 ============
 
-1. Using Composer (recommended)
--------------------------------
+Step 1: Download the Bundle
+---------------------------
 
-To install JMSSerializerBundle with Composer just add the following to your
-`composer.json` file:
+Open a command console, enter your project directory and execute the
+following command to download the latest stable version of this bundle:
 
-.. code-block :: js
+.. code-block:: bash
 
-    // composer.json
+    $ composer require jms/serializer-bundle "~0.13"
+
+This command requires you to have Composer installed globally, as explained
+in the `installation chapter <https://getcomposer.org/doc/00-intro.md>`_
+of the Composer documentation.
+
+Step 2: Enable the Bundle
+-------------------------
+
+Then, enable the bundle by adding the following line in the ``app/AppKernel.php``
+file of your project:
+
+.. code-block:: php
+
+    <?php
+    // app/AppKernel.php
+
+    // ...
+    class AppKernel extends Kernel
     {
-        // ...
-        require: {
+        public function registerBundles()
+        {
+            $bundles = array(
+                // ...
+                return new JMS\SerializerBundle\JMSSerializerBundle(),
+            );
+
             // ...
-            "jms/serializer-bundle": "dev-master"
         }
     }
-    
-.. note ::
-
-    Please replace `dev-master` in the snippet above with the latest stable
-    branch, for example ``1.0.*``.
-    
-If you're using the Symfony Standard Edition, also make sure that you increase the
-versions for ``jms/di-extra-bundle`` to ``1.3.*``, and ``jms/security-extra-bundle`` to ``1.4.*``.
-
-Then, you can install the new dependencies by running Composer's ``update``
-command from the directory where your ``composer.json`` file is located:
-
-.. code-block :: bash
-
-    $ php composer.phar update
-    
-Now, Composer will automatically download all required files, and install them
-for you. All that is left to do is to update your ``AppKernel.php`` file, and
-register the new bundle:
-
-.. code-block :: php
-
-    <?php
-
-    // in AppKernel::registerBundles()
-    $bundles = array(
-        // ...
-        new JMS\SerializerBundle\JMSSerializerBundle(),
-        // ...
-    );
-    
-2. Using the ``deps`` file (Symfony 2.0.x)
-------------------------------------------
-
-First, checkout a copy of the code. Just add the following to the ``deps`` 
-file of your Symfony Standard Distribution:
-
-.. code-block :: ini
-
-    [JMSSerializerBundle]
-        git=git://github.com/schmittjoh/JMSSerializerBundle.git
-        target=bundles/JMS/SerializerBundle
-
-Then register the bundle with your kernel:
-
-.. code-block :: php
-
-    <?php
-
-    // in AppKernel::registerBundles()
-    $bundles = array(
-        // ...
-        new JMS\Serializer\JMSSerializerBundle($this),
-        // ...
-    );
-
-This bundle also requires the Metadata library (**you need the 1.1 version, not the 1.0
-version** which ships with the Symfony Standard Edition.):
-
-.. code-block :: ini
-
-    [metadata]
-        git=http://github.com/schmittjoh/metadata.git
-        version=1.1.0
-
-Make sure that you also register the namespaces with the autoloader:
-
-.. code-block :: php
-
-    <?php
-
-    // app/autoload.php
-    $loader->registerNamespaces(array(
-        // ...
-        'JMS'              => __DIR__.'/../vendor/bundles',
-        'Metadata'         => __DIR__.'/../vendor/metadata/src',
-        // ...
-    ));
-
-Now use the ``vendors`` script to clone the newly added repositories 
-into your project:
-
-.. code-block :: bash
-
-    $ php bin/vendors install


### PR DESCRIPTION
_The Symfony Documenators started an initiative to make all bundle installation documentation consistent and  easy to understand for beginners. That'll improve the DX for starters using 3rd party bundles. The template can be found here: http://symfony.com/doc/current/cookbook/bundles/best_practices.html#installation-instructions_

I would like to ask you to use this template in your documentation.

If you have any comments on the template, please open an issue in the `symfony/symfony-docs` repository. Feedback will brings us to the ultimate template.
