### PR TITLE
Fix jms_serializer.infer_types_from_doctrine_metadata usage

### DIFF
--- a/DependencyInjection/Compiler/DoctrinePass.php
+++ b/DependencyInjection/Compiler/DoctrinePass.php
@@ -10,7 +10,8 @@ class DoctrinePass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (!$container->getParameter('jms_serializer.infer_types_from_doctrine_metadata')) {
+        if ($container->hasParameter('jms_serializer.infer_types_from_doctrine_metadata') 
+            && $container->getParameter('jms_serializer.infer_types_from_doctrine_metadata') === false) {
             return;
         }
 

--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -76,8 +76,8 @@ class JMSSerializerExtension extends ConfigurableExtension
             $container->setAlias('jms_serializer.metadata.cache', new Alias($config['metadata']['cache'], false));
         }
 
-        if ($config['metadata']['infer_types_from_doctrine_metadata']) {
-            $container->setParameter('jms_serializer.infer_types_from_doctrine_metadata', true);
+        if ($config['metadata']['infer_types_from_doctrine_metadata'] === false) {
+            $container->setParameter('jms_serializer.infer_types_from_doctrine_metadata', false);
         }
 
         $container


### PR DESCRIPTION
Hi,

Adding:

    jms_serializer:
        metadata:
            infer_types_from_doctrine_metadata: false

Was not working because of the test in JMSSerializerExtension.php. To make the DoctrinePass work, it has to test if the parameter is set, and if the value is set to false. 

Thanks 
