### PR TITLE
ContextErrorException: call_user_func() expects parameter 1 to be...

### DIFF
--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -8,7 +8,7 @@ or the ``jms_serializer.subscribing_handler``.
 
 .. code-block :: xml
 
-    <service id="my_handler" class="MyHandler" public="false">
+    <service id="my_handler" class="MyHandler">
         <tag name="jms_serializer.handler" type="DateTime" direction="serialization" format="json"
                     method="serializeDateTimeToJson" />
     </service>


### PR DESCRIPTION
I was getting:

```
ContextErrorException: Warning: call_user_func() expects parameter 1 to be a valid callback, class 'my.serializer.handler.image' not found in vendor/jms/serializer/src/JMS/Serializer/GraphNavigator.php line 172
```

Removing `public="false"` fixed it.