### PR TITLE
add service definition for IdenticalPropertyNamingStrategy

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -21,6 +21,7 @@
         <parameter key="jms_serializer.event_dispatcher.class">JMS\Serializer\EventDispatcher\LazyEventDispatcher</parameter>
 
         <parameter key="jms_serializer.camel_case_naming_strategy.class">JMS\Serializer\Naming\CamelCaseNamingStrategy</parameter>
+        <parameter key="jms_serializer.identical_property_naming_strategy.class">JMS\Serializer\Naming\IdenticalPropertyNamingStrategy</parameter>
         <parameter key="jms_serializer.serialized_name_annotation_strategy.class">JMS\Serializer\Naming\SerializedNameAnnotationStrategy</parameter>
         <parameter key="jms_serializer.cache_naming_strategy.class">JMS\Serializer\Naming\CacheNamingStrategy</parameter>
 
@@ -147,6 +148,7 @@
 
         <!-- Naming Strategies -->
         <service id="jms_serializer.camel_case_naming_strategy" class="%jms_serializer.camel_case_naming_strategy.class%" public="false" />
+        <service id="jms_serializer.identical_property_naming_strategy" class="%jms_serializer.identical_property_naming_strategy.class%" public="false" />
         <service id="jms_serializer.serialized_name_annotation_strategy" class="%jms_serializer.serialized_name_annotation_strategy.class%" public="false">
             <argument type="service" id="jms_serializer.camel_case_naming_strategy" />
         </service>


### PR DESCRIPTION
I ran into issue #397 which can be solved without adding a new strategy class (as suggested in the issue) by using `SerializedNameAnnotationStrategy` with `IdenticalPropertyNamingStrategy` as delegate:

``` yml
services:
    my_custom_naming_strategy:
        class: %jms_serializer.serialized_name_annotation_strategy.class%
        public: false
        arguments:
            - @jms_serializer.identical_property_naming_strategy

    jms_serializer.naming_strategy:
        alias: my_custom_naming_strategy
```

However the bundle does not define the `IdenticalPropertyNamingStrategy` as it does with other strategies. This PR adds the definition for a `jms_serializer.identical_property_naming_strategy` service which can be referenced from a custom strategy service definition.

Until this PR is merged, you can add the following (e.g. to your `services.yml`):

``` yml
parameters:
    jms_serializer.identical_property_naming_strategy.class: JMS\Serializer\Naming\IdenticalPropertyNamingStrategy

services:
    jms_serializer.identical_property_naming_strategy:
        class: %jms_serializer.identical_property_naming_strategy.class%
        public: false

[...definitions as above...]
```
