### PR TITLE
[Feature] command to list used SerializationGroups

### DIFF
--- a/Command/ListSerializationGroupsCommand.php
+++ b/Command/ListSerializationGroupsCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ListSerilizationGroupsCommand extends ContainerAwareCommand
+class ListSerializationGroupsCommand extends ContainerAwareCommand
 {
     private $usedGroups = [];
 
@@ -37,7 +37,7 @@ class ListSerilizationGroupsCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
-            ->setName('serializer:list-groups')
+            ->setName('jms:serializer:list-groups')
             ->setDescription('list all groups used on the entites')
             ->addOption('short', null, InputOption::VALUE_OPTIONAL, 'print the occurences of each group', false);
     }

--- a/Command/ListSerilizationGroupsCommand.php
+++ b/Command/ListSerilizationGroupsCommand.php
@@ -1,0 +1,164 @@
+<?php
+namespace JMS\SerializerBundle\Command;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListSerilizationGroupsCommand extends ContainerAwareCommand
+{
+    private $usedGroups = [];
+
+    /**
+     * @var int
+     */
+    private $maxClassNameLength = 0;
+
+    /**
+     * @var int
+     */
+    private $maxGroupNameLength = 0;
+
+    /**
+     * @var InputInterface
+     */
+    private $input;
+
+    /**
+     * @var Output
+     */
+    private $output;
+
+    protected function configure()
+    {
+        $this
+            ->setName('serializer:list-groups')
+            ->setDescription('list all groups used on the entites')
+            ->addOption('short', null, InputOption::VALUE_OPTIONAL, 'print the occurences of each group', false);
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return int|null|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->output = $output;
+        $this->input = $input;
+
+        $this->output->writeln('<info>fetching groups from entity manager...</info>');
+        $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+
+        $knownEntities = $em->getMetadataFactory()->getAllMetadata();
+        $this->getJmsGroups($knownEntities);
+        $this->detectMaxOutputLength();
+
+        $this->printGroups($input->getOption('short'));
+    }
+
+    /**
+     * @param string $group
+     * @param string $propertyClass
+     */
+    protected function addToUsedGroups($group, $propertyClass)
+    {
+        if (!isset($this->usedGroups[$group])) {
+            $this->usedGroups[$group] = [];
+        }
+        if (!isset($this->usedGroups[$group][$propertyClass])) {
+            $this->usedGroups[$group][$propertyClass] = 0;
+        }
+        $this->usedGroups[$group][$propertyClass] += 1 ;
+    }
+
+    /**
+     * @param $groupOccurence
+     * @return array
+     */
+    protected function printGroupOccurences($groupOccurence)
+    {
+        foreach ($groupOccurence as $className => $count) {
+            $maxWidth = $this->maxClassNameLength + 2;
+            $diffToMaxLength = $this->maxClassNameLength - strlen($className);
+            $offset = $maxWidth - $diffToMaxLength;
+            $this->output->writeln(sprintf('%'.$offset.'s %'.$diffToMaxLength.'d', $className, $count));
+        }
+        $this->output->writeln('');
+    }
+
+    /**
+     * @param string $groupName
+     * @param int $count
+     */
+    protected function printGroup($groupName, $count)
+    {
+        $this->output->writeln(sprintf('<fg=yellow>%s</fg=yellow> (%d occurences)', $groupName, $count));
+    }
+
+    protected function detectMaxOutputLength()
+    {
+        foreach ($this->usedGroups as $group => $occurences) {
+            $this->maxClassNameLength = max(
+                max(array_map('strlen', array_keys($occurences))),
+                $this->maxClassNameLength
+            );
+            $this->maxGroupNameLength = max(strlen($group), $this->maxGroupNameLength);
+        }
+    }
+
+    /**
+     * @param $jmsMetadata
+     */
+    protected function fetchJmsGroupsFromMetadata($jmsMetadata)
+    {
+        /** @var PropertyMetadata $property */
+        foreach ($jmsMetadata->propertyMetadata as $property) {
+            $groups = $property->groups;
+            if (!empty($groups)) {
+                foreach ($groups as $group) {
+                    if ($this->output->isDebug()) {
+                        $this->output->writeln('found group in class ' . $property->class . ': ' . $group);
+                    }
+                    $this->addToUsedGroups($group, $property->class);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param ClassMetadata[] $knownEntities
+     */
+    protected function getJmsGroups($knownEntities)
+    {
+        $this->output->writeln('<info>checking for serializer metadata...</info>');
+        $serializer = $this->getContainer()->get('jms_serializer');
+        foreach ($knownEntities as $entity) {
+            $jmsMetadata = $serializer->getMetadataFactory()->getMetadataForClass(
+                $entity->getReflectionClass()->getName()
+            );
+            $this->fetchJmsGroupsFromMetadata($jmsMetadata);
+        }
+        $this->output->writeln('<info>done.</info>' . PHP_EOL);
+    }
+
+    /**
+     * @param bool $short
+     */
+    protected function printGroups($short = false)
+    {
+        $this->output->writeln('Found groups:');
+        foreach ($this->usedGroups as $groupName => $groupOccurence) {
+            $count = array_sum(array_values($groupOccurence));
+            $this->printGroup($groupName, $count);
+
+            if (!$short) {
+                $this->printGroupOccurences($groupOccurence);
+            }
+        }
+    }
+}

--- a/Command/ListSerilizationGroupsCommand.php
+++ b/Command/ListSerilizationGroupsCommand.php
@@ -1,7 +1,9 @@
 <?php
 namespace JMS\SerializerBundle\Command;
-use Doctrine\ORM\Mapping\ClassMetadata;
+
 use JMS\Serializer\Metadata\PropertyMetadata;
+use Metadata\MergeableClassMetadata;
+use Metadata\MetadataFactory;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -106,7 +108,7 @@ class ListSerilizationGroupsCommand extends ContainerAwareCommand
     }
 
     /**
-     * @param $jmsMetadata
+     * @param MergeableClassMetadata $jmsMetadata
      */
     protected function fetchJmsGroupsFromMetadata($jmsMetadata)
     {
@@ -128,9 +130,11 @@ class ListSerilizationGroupsCommand extends ContainerAwareCommand
     {
         $this->output->writeln('<info>checking for serializer metadata...</info>');
         $serializer = $this->getContainer()->get('jms_serializer');
-        $knownClasses = $serializer->getMetadataFactory()->getAllClassNames();
+        /** @var MetadataFactory $metadataFactory */
+        $metadataFactory = $serializer->getMetadataFactory();
+        $knownClasses = $metadataFactory->getAllClassNames();
         foreach ($knownClasses as $class) {
-            $jmsMetadata = $serializer->getMetadataFactory()->getMetadataForClass($class);
+            $jmsMetadata = $metadataFactory->getMetadataForClass($class);
             $this->fetchJmsGroupsFromMetadata($jmsMetadata);
         }
         $this->output->writeln('<info>done.</info>' . PHP_EOL);

--- a/Command/ListSerilizationGroupsCommand.php
+++ b/Command/ListSerilizationGroupsCommand.php
@@ -50,14 +50,8 @@ class ListSerilizationGroupsCommand extends ContainerAwareCommand
     {
         $this->output = $output;
         $this->input = $input;
-
-        $this->output->writeln('<info>fetching groups from entity manager...</info>');
-        $em = $this->getContainer()->get('doctrine.orm.entity_manager');
-
-        $knownEntities = $em->getMetadataFactory()->getAllMetadata();
-        $this->getJmsGroups($knownEntities);
+        $this->getJmsGroups();
         $this->detectMaxOutputLength();
-
         $this->printGroups($input->getOption('short'));
     }
 
@@ -130,17 +124,13 @@ class ListSerilizationGroupsCommand extends ContainerAwareCommand
         }
     }
 
-    /**
-     * @param ClassMetadata[] $knownEntities
-     */
-    protected function getJmsGroups($knownEntities)
+    protected function getJmsGroups()
     {
         $this->output->writeln('<info>checking for serializer metadata...</info>');
         $serializer = $this->getContainer()->get('jms_serializer');
-        foreach ($knownEntities as $entity) {
-            $jmsMetadata = $serializer->getMetadataFactory()->getMetadataForClass(
-                $entity->getReflectionClass()->getName()
-            );
+        $knownClasses = $serializer->getMetadataFactory()->getAllClassNames();
+        foreach ($knownClasses as $class) {
+            $jmsMetadata = $serializer->getMetadataFactory()->getMetadataForClass($class);
             $this->fetchJmsGroupsFromMetadata($jmsMetadata);
         }
         $this->output->writeln('<info>done.</info>' . PHP_EOL);

--- a/Tests/Command/Fixture/ExampleEntity.php
+++ b/Tests/Command/Fixture/ExampleEntity.php
@@ -1,0 +1,22 @@
+<?php
+namespace JMS\SerializerBundle\Tests\Command\Fixture;
+
+use JMS\Serializer\Annotation\Groups;
+
+class ExampleEntity {
+
+    /**
+     * @Groups({"TestGroup1"})
+     */
+    public $property;
+
+    /**
+     * @Groups({"TestGroup2", "TestGroup3"})
+     */
+    public $otherProperty;
+
+    /**
+     * @Groups({"TestGroup2"})
+     */
+    public $anotherProperty;
+}

--- a/Tests/Command/ListSerializationGroupsCommandTest.php
+++ b/Tests/Command/ListSerializationGroupsCommandTest.php
@@ -40,9 +40,9 @@ class ListSerializationGroupsCommandTest extends WebTestCase
     public function testExecute()
     {
         $application = new Application($this->kernelMock);
-        $listSerilizationGroupsCommand = new ListSerializationGroupsCommand();
-        $listSerilizationGroupsCommand->setContainer($this->kernelMock->getContainer());
-        $application->add($listSerilizationGroupsCommand);
+        $listSerializationGroupsCommand = new ListSerializationGroupsCommand();
+        $listSerializationGroupsCommand->setContainer($this->kernelMock->getContainer());
+        $application->add($listSerializationGroupsCommand);
 
         $command = $application->find('jms:serializer:list-groups');
         $commandTester = new CommandTester($command);

--- a/Tests/Command/ListSerializationGroupsCommandTest.php
+++ b/Tests/Command/ListSerializationGroupsCommandTest.php
@@ -2,8 +2,12 @@
 namespace JMS\SerializerBundle\Tests\Command;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
+use JMS\Serializer\Serializer;
 use JMS\SerializerBundle\Tests\Command\Fixture\ExampleEntity;
+use Metadata\MetadataFactory;
+use ReflectionClass;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\WebTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -15,6 +19,8 @@ class ListSerializationGroupsCommandTest extends WebTestCase
      * @var \Symfony\Component\HttpKernel\Kernel|\PHPUnit_Framework_MockObject_MockObject
      */
     private $kernelMock;
+    private $emMock;
+    private $doctrineMetadataFactoryMock;
 
     public function setUp()
     {
@@ -28,13 +34,29 @@ class ListSerializationGroupsCommandTest extends WebTestCase
         $serializerMock = $this->getMockBuilder('JMS\Serializer\Serialize')
             ->setMethods(['getMetadataFactory'])
             ->getMock();
-        $metadataFactory = $this->getMockBuilder('\Metadata\MetadataFactory')->disableOriginalConstructor()->getMock();
+        $this->emMock = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+            ->disableOriginalConstructor('Doctrine\ORM\EntityManager')
+            ->getMock();
+        $this->doctrineMetadataFactoryMock = $this->getMockBuilder('\Doctrine\ORM\Mapping\ClassMetadataFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $classMetadata = new ClassMetadata('ExampleEntity');
+        $reflClass = new ReflectionClass('ExampleEntity');
+        $classMetadata->reflClass = $reflClass;
+        $this->doctrineMetadataFactoryMock->expects($this->once())
+            ->method('getAllMetadata')
+            ->willReturn([$classMetadata]);
+
+        $this->emMock->expects($this->once())
+            ->method('getMetadataFactory')
+            ->willReturn($this->doctrineMetadataFactoryMock);
+
         $annotationDriver = new AnnotationDriver(new AnnotationReader());
-        $metadata = $annotationDriver->loadMetadataForClass(new \ReflectionClass(new ExampleEntity()));
-        $metadataFactory->expects($this->once())->method('getMetadataForClass')->willReturn($metadata);
-        $metadataFactory->expects($this->once())->method('getAllClassNames')->willReturn(['ExampleEntity']);
-        $serializerMock->expects($this->any())->method('getMetadataFactory')->willReturn($metadataFactory);
-        $containerMock->expects($this->exactly(1))->method('get')->with('jms_serializer')->willReturn($serializerMock);
+        $factory = new MetadataFactory($annotationDriver);
+        $serializerMock->expects($this->any())->method('getMetadataFactory')->willReturn($factory);
+        $containerMock->expects($this->at(0))->method('get')->with('doctrine.orm.entity_manager')->willReturn($this->emMock);
+        $containerMock->expects($this->at(1))->method('get')->with('jms_serializer')->willReturn($serializerMock);
     }
 
     public function testExecute()

--- a/Tests/Command/ListSerializationGroupsCommandTest.php
+++ b/Tests/Command/ListSerializationGroupsCommandTest.php
@@ -1,0 +1,56 @@
+<?php
+namespace JMS\SerializerBundle\Tests\Command;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use JMS\Serializer\Metadata\Driver\AnnotationDriver;
+use JMS\SerializerBundle\Tests\Command\Fixture\ExampleEntity;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\WebTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use JMS\SerializerBundle\Command\ListSerializationGroupsCommand;
+
+class ListSerializationGroupsCommandTest extends WebTestCase
+{
+    /**
+     * @var \Symfony\Component\HttpKernel\Kernel|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $kernelMock;
+
+    public function setUp()
+    {
+        $containerMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\Container')
+            ->disableOriginalConstructor()->getMock();
+        $this->kernelMock = $this->getMockBuilder('Symfony\Component\HttpKernel\Kernel')
+            ->disableOriginalConstructor()->getMock();
+        $this->kernelMock->expects($this->any())
+            ->method('getContainer')
+            ->willReturn($containerMock);
+        $serializerMock = $this->getMockBuilder('JMS\Serializer\Serialize')
+            ->setMethods(['getMetadataFactory'])
+            ->getMock();
+        $metadataFactory = $this->getMockBuilder('\Metadata\MetadataFactory')->disableOriginalConstructor()->getMock();
+        $annotationDriver = new AnnotationDriver(new AnnotationReader());
+        $metadata = $annotationDriver->loadMetadataForClass(new \ReflectionClass(new ExampleEntity()));
+        $metadataFactory->expects($this->once())->method('getMetadataForClass')->willReturn($metadata);
+        $metadataFactory->expects($this->once())->method('getAllClassNames')->willReturn(['ExampleEntity']);
+        $serializerMock->expects($this->any())->method('getMetadataFactory')->willReturn($metadataFactory);
+        $containerMock->expects($this->exactly(1))->method('get')->with('jms_serializer')->willReturn($serializerMock);
+    }
+
+    public function testExecute()
+    {
+        $application = new Application($this->kernelMock);
+        $listSerilizationGroupsCommand = new ListSerializationGroupsCommand();
+        $listSerilizationGroupsCommand->setContainer($this->kernelMock->getContainer());
+        $application->add($listSerilizationGroupsCommand);
+
+        $command = $application->find('jms:serializer:list-groups');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName()));
+
+        $output = $commandTester->getDisplay();
+        $this->assertRegExp('/TestGroup1 \(1 occurences\)/', $output);
+        $this->assertRegExp('/TestGroup2 \(2 occurences\)/', $output);
+        $this->assertRegExp('/TestGroup3/', $output);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "doctrine/orm": "*",
         "symfony/form": "*",
         "symfony/validator": "*",
-        "symfony/stopwatch": "*"
+        "symfony/stopwatch": "*",
+        "phpunit/phpunit": "~4.8"
     },
     "suggest": {
         "jms/di-extra-bundle": "Required to get lazy loading (de)serialization visitors, ~1.3"


### PR DESCRIPTION
I added a command that fetches all Groups from classes known to the serializer.

``` php
app/console jms:serializer:list-groups
```

Output:

```
checking for serializer metadata...
done.

Found groups:
TestGroup1 (1 occurences)
  JMS\SerializerBundle\Tests\Command\Fixture\ExampleEntity 1

TestGroup2 (2 occurences)
  JMS\SerializerBundle\Tests\Command\Fixture\ExampleEntity 2

TestGroup3 (1 occurences)
  JMS\SerializerBundle\Tests\Command\Fixture\ExampleEntity 1
```

with entity:

``` php
class ExampleEntity {

    /**
     * @Groups({"TestGroup1"})
     */
    public $property;

    /**
     * @Groups({"TestGroup2", "TestGroup3"})
     */
    public $otherProperty;

    /**
     * @Groups({"TestGroup2"})
     */
    public $anotherProperty;
}
```

or with `--short=true` flag:

```
checking for serializer metadata...
done.

Found groups:
TestGroup1 (1 occurences)
TestGroup2 (2 occurences)
TestGroup3 (1 occurences)
```
