### PR TITLE
enable serialization of symfony's violation api

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" />
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectRootManager" version="2" />
-</project>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -51,6 +51,7 @@
         <parameter key="jms_serializer.constraint_violation_handler.class">JMS\Serializer\Handler\ConstraintViolationHandler</parameter>
         <parameter key="jms_serializer.doctrine_proxy_subscriber.class">JMS\Serializer\EventDispatcher\Subscriber\DoctrineProxySubscriber</parameter>
         <parameter key="jms_serializer.stopwatch_subscriber.class">JMS\SerializerBundle\Serializer\StopwatchEventSubscriber</parameter>
+        <parameter key="jms_serializer.constraint_violation_converter.class">JMS\SerializerBundle\Serializer\ConstraintViolationListSubscriber</parameter>
     </parameters>
 
     <services>
@@ -64,6 +65,9 @@
         <service id="jms_serializer.stopwatch_subscriber" class="%jms_serializer.stopwatch_subscriber.class%">
             <tag name="jms_serializer.event_subscriber" />
             <argument type="service" id="debug.stopwatch" />
+        </service>
+        <service id="jms_serializer.constraint_violation_converter.class" class="%jms_serializer.constraint_violation_converter.class%">
+            <tag name="jms_serializer.event_subscriber" />
         </service>
         
         <!-- Handlers -->

--- a/Serializer/ConstraintViolationListSubscriber.php
+++ b/Serializer/ConstraintViolationListSubscriber.php
@@ -1,0 +1,94 @@
+<?php
+ 
+namespace JMS\SerializerBundle\Serializer;
+
+use JMS\Serializer\Context;
+use JMS\Serializer\EventDispatcher\Events;
+use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
+use JMS\Serializer\EventDispatcher\PreSerializeEvent;
+use ReflectionProperty;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+/**
+ * @author Maximilian Bosch <ma27.git@gmail.com>
+ */
+class ConstraintViolationListSubscriber implements EventSubscriberInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            array('event' => Events::PRE_SERIALIZE, 'method' => 'onPreSerialize', 'priority' => 512),
+        );
+    }
+
+    /**
+     * Converts a constraint violation list to an array
+     *
+     * @param PreSerializeEvent $event
+     */
+    public function onPreSerialize(PreSerializeEvent $event)
+    {
+        if (!class_exists('Symfony\\Component\\Validator\\ConstraintViolationListInterface')) {
+            return;
+        }
+
+        if (null === $object = $this->getRootObjectByGraph($event->getContext())) {
+            return;
+        }
+
+        if (!$object instanceof ConstraintViolationListInterface) {
+            return;
+        }
+
+        $newObject = array();
+
+        foreach ($object as $constraintViolation) {
+            if (!$constraintViolation instanceof ConstraintViolationInterface) {
+                throw new \LogicException(
+                    sprintf(
+                        'Every violation must be an instance of "%s"',
+                        'Symfony\\Component\\Validator\\ConstraintViolationInterface'
+                    )
+                );
+            }
+
+            $property = $constraintViolation->getPropertyPath();
+
+            if (!isset($newObject[$property])) {
+                $newObject[$property] = array();
+            }
+
+            $newObject[$property][] = $constraintViolation->getMessage();
+        }
+
+        // the object of the preserialize event should be changeable
+        // this is just workaround
+        // I'll open a pull request on jms/serializer in order to fix this, but
+        // until that, this workaround should help
+        $reflection = new ReflectionProperty('JMS\\Serializer\\EventDispatcher\\PreSerializeEvent', 'object');
+
+        $reflection->setAccessible(true);
+        $reflection->setValue($event, $newObject);
+        $reflection->setAccessible(false);
+    }
+
+    /**
+     * Returns the root object or null
+     *
+     * @param Context $context
+     *
+     * @return mixed
+     */
+    private function getRootObjectByGraph(Context $context)
+    {
+        if ($context->getDepth() > 1) {
+            return;
+        }
+
+        return $context->getObject();
+    }
+}


### PR DESCRIPTION
when validating values using the symfony validator, I'd like to return the ConstraintViolationList in my controller code.
But there'll occur issues when using the serializer.
So I've implemented a listener which converts the ConstraintViolationListInterface to an array of error messages sorted by their properties