### PR TITLE
Update composer.json, php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.4.0",
         "jms/serializer": "^1.0.0",
         "symfony/framework-bundle": "~2.1"
     },


### PR DESCRIPTION
Fix php version in composer.json. schmittjoh/serializer require php 5.4.0. JMSSerializerBundle raise a conflict in composer.
