### PR TITLE
Allow service parameters in listener and subscriber service

### DIFF
--- a/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
+++ b/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
@@ -54,8 +54,8 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
                     throw new \RuntimeException(sprintf('The service "%s" (class: %s) must return an event for each subscribed event.', $id, $subscriberClass));
                 }
 
-                $class = isset($attributes['class'])
-                    ? strtolower($container->getParameterBag()->resolveValue($attributes['class']))
+                $class = isset($eventData['class'])
+                    ? strtolower($container->getParameterBag()->resolveValue($eventData['class']))
                     : null
                 ;
 

--- a/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
+++ b/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
@@ -22,7 +22,11 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
                     throw new \RuntimeException(sprintf('The tag "jms_serializer.event_listener" of service "%s" requires an attribute named "event".', $id));
                 }
 
-                $class = isset($attributes['class']) ? strtolower($attributes['class']) : null;
+                $class = isset($attributes['class'])
+                    ? strtolower($container->getParameterBag()->resolveValue($attributes['class']))
+                    : null
+                ;
+
                 $format = isset($attributes['format']) ? $attributes['format'] : null;
                 $method = isset($attributes['method']) ? $attributes['method'] : EventDispatcher::getDefaultMethodName($attributes['event']);
                 $priority = isset($attributes['priority']) ? (integer) $attributes['priority'] : 0;
@@ -50,7 +54,11 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
                     throw new \RuntimeException(sprintf('The service "%s" (class: %s) must return an event for each subscribed event.', $id, $subscriberClass));
                 }
 
-                $class = isset($eventData['class']) ? strtolower($eventData['class']) : null;
+                $class = isset($attributes['class'])
+                    ? strtolower($container->getParameterBag()->resolveValue($attributes['class']))
+                    : null
+                ;
+
                 $format = isset($eventData['format']) ? $eventData['format'] : null;
                 $method = isset($eventData['method']) ? $eventData['method'] : EventDispatcher::getDefaultMethodName($eventData['event']);
                 $priority = isset($eventData['priority']) ? (integer) $eventData['priority'] : 0;


### PR DESCRIPTION
Allow service parameters in listener and subscriber service definition for the option `class`.

This is necessary for when you have a system where the model can be easily override (Sylius in my case). Here the model class is stored as a service parameter (e.g. `%acme.model.user.class%`). With this PR it is possible to use container parameters for the `class` option.
