### PR TITLE
dev-master of jms/serializer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "jms/serializer": "^1.0.0",
+        "jms/serializer": "dev-master",
         "symfony/framework-bundle": "~2.1"
     },
     "require-dev": {


### PR DESCRIPTION
Fix version to have 'dev-master' of jms/serializer if 'dev-master' of JMSSerializerBundle
