### PR TITLE
Use ATOM format as default for datetimes to follow the ISO8601 standard

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -62,7 +62,7 @@ class Configuration implements ConfigurationInterface
                     ->arrayNode('datetime')
                         ->addDefaultsIfNotSet()
                         ->children()
-                            ->scalarNode('default_format')->defaultValue(\DateTime::ISO8601)->end()
+                            ->scalarNode('default_format')->defaultValue(\DateTime::ATOM)->end()
                             ->scalarNode('default_timezone')->defaultValue(date_default_timezone_get())->end()
                             ->scalarNode('cdata')->defaultTrue()->end()
                         ->end()


### PR DESCRIPTION
Even that `\DateTime::ISO8601` looks like ISO8601 compatible, it's not :cry: 

So I think that the default datetime format should follow the standard by default.

http://php.net/manual/en/class.datetime.php
