### PR TITLE
Using class names instead of service identifiers inside of callback.

### DIFF
--- a/DependencyInjection/Compiler/CustomHandlersPass.php
+++ b/DependencyInjection/Compiler/CustomHandlersPass.php
@@ -29,7 +29,7 @@ class CustomHandlersPass implements CompilerPassInterface
 
                 foreach ($directions as $direction) {
                     $method = isset($attrs['method']) ? $attrs['method'] : HandlerRegistry::getDefaultMethod($direction, $attrs['type'], $attrs['format']);
-                    $handlers[$direction][$attrs['type']][$attrs['format']] = array($id, $method);
+                    $handlers[$direction][$attrs['type']][$attrs['format']] = array($class, $method);
                 }
             }
         }
@@ -53,7 +53,7 @@ class CustomHandlersPass implements CompilerPassInterface
 
                 foreach ($directions as $direction) {
                     $method = isset($methodData['method']) ? $methodData['method'] : HandlerRegistry::getDefaultMethod($direction, $methodData['type'], $methodData['format']);
-                    $handlers[$direction][$methodData['type']][$methodData['format']] = array($id, $method);
+                    $handlers[$direction][$methodData['type']][$methodData['format']] = array($class, $method);
                 }
             }
         }


### PR DESCRIPTION
The compiler pass mistakingly uses the service identifier in the callback instead of the name of the class itself. This causes the following error when register handlers: "Warning: call_user_func() expects parameter 1 to be a valid callback, class 'the.service.identifier' not found"