### PR TITLE
Fix metadata directories loading where path is just a bundle name

### DIFF
--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -98,7 +98,8 @@ class JMSSerializerExtension extends ConfigurableExtension
             $directory['path'] = rtrim(str_replace('\\', '/', $directory['path']), '/');
 
             if ('@' === $directory['path'][0]) {
-                $bundleName = substr($directory['path'], 1, strpos($directory['path'], '/') - 1);
+                $pathParts = explode('/', $directory['path']);
+                $bundleName = substr($pathParts[0], 1);
 
                 if (!isset($bundles[$bundleName])) {
                     throw new RuntimeException(sprintf('The bundle "%s" has not been registered with AppKernel. Available bundles: %s', $bundleName, implode(', ', array_keys($bundles))));

--- a/Tests/DependencyInjection/JMSSerializerExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSerializerExtensionTest.php
@@ -26,7 +26,6 @@ use JMS\SerializerBundle\Tests\DependencyInjection\Fixture\SimpleObject;
 use JMS\SerializerBundle\Tests\DependencyInjection\Fixture\VersionedObject;
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\KernelInterface;
 
 class JMSSerializerExtensionTest extends \PHPUnit_Framework_TestCase
 {
@@ -146,16 +145,39 @@ class JMSSerializerExtensionTest extends \PHPUnit_Framework_TestCase
         return $configs;
     }
 
-    private function getContainerForConfig(array $configs, KernelInterface $kernel = null)
+    public function testCustomMetadataDirectories()
     {
-        if (null === $kernel) {
-            $kernel = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');
-            $kernel
-                ->expects($this->any())
-                ->method('getBundles')
-                ->will($this->returnValue(array()))
-            ;
-        }
+        $modifyContainer = function(ContainerBuilder $container) {
+            $container->setParameter('kernel.bundles', array(
+                'FrameworkBundle' => 'Symfony\Bundle\FrameworkBundle\FrameworkBundle'
+            ));
+        };
+
+        $container = $this->getContainerForConfig(array(
+            array(
+                'metadata' => array(
+                    'auto_detection' => false,
+                    'directories' => array(
+                        'test' => array(
+                            'namespace_prefix' => 'prefix',
+                            'path'             => '@FrameworkBundle'
+                        ),
+                    )
+                )
+            )
+        ), $modifyContainer);
+
+        $this->assertFileExists($container->getDefinition('jms_serializer.metadata.file_locator')->getArgument(0)['prefix']);
+    }
+
+    private function getContainerForConfig(array $configs, callable $modifyContainer = null)
+    {
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');
+        $kernel
+            ->expects($this->any())
+            ->method('getBundles')
+            ->will($this->returnValue(array()))
+        ;
 
         $bundle = new JMSSerializerBundle($kernel);
         $extension = $bundle->getContainerExtension();
@@ -168,6 +190,11 @@ class JMSSerializerExtensionTest extends \PHPUnit_Framework_TestCase
         $container->set('translator', $this->getMock('Symfony\\Component\\Translation\\TranslatorInterface'));
         $container->set('debug.stopwatch', $this->getMock('Symfony\\Component\\Stopwatch\\Stopwatch'));
         $container->registerExtension($extension);
+
+        if ($modifyContainer) {
+            call_user_func($modifyContainer, $container);
+        }
+
         $extension->load($configs, $container);
 
         $bundle->build($container);


### PR DESCRIPTION
Currently if you specify a metadata directory path in your config as something like just `@AppBundle` (no forward slash) it will truncate the last character and then search for a bundle named `AppBundl` - this of course throws an exception.

This pull request both fixes that issue and adds a test to cover it.
