### PR TITLE
Added configuration for default context

### DIFF
--- a/ContextFactory/ConfiguredContextFactory.php
+++ b/ContextFactory/ConfiguredContextFactory.php
@@ -14,20 +14,47 @@ use JMS\Serializer\SerializationContext;
 class ConfiguredContextFactory implements SerializationContextFactoryInterface, DeserializationContextFactoryInterface
 {
     /**
-     * Context config
+     * Application version
+     *
+     * @var null|string
+     */
+    private $version;
+
+    /**
+     * Flag if we should serialize null values
+     *
+     * @var bool
+     */
+    private $serializeNulls;
+
+    /**
+     * Key-value pairs with custom attributes
      *
      * @var array
      */
-    private $config;
+    private $attributes;
+
+    /**
+     * Serialization groups
+     *
+     * @var string[]
+     */
+    private $groups;
 
     /**
      * ConfiguredContextFactory constructor.
      *
-     * @param array $config Context configuration
+     * @param string|null $version        Application version
+     * @param bool        $serializeNulls Flag if we should serialize null values
+     * @param array       $attributes     Key-value pairs with custom attributes
+     * @param string[]    $groups         Serialization groups
      */
-    public function __construct(array $config)
+    public function __construct($version, $serializeNulls, array $attributes, array $groups)
     {
-        $this->config = $config;
+        $this->version = $version;
+        $this->serializeNulls = $serializeNulls;
+        $this->attributes = $attributes;
+        $this->groups = $groups;
     }
 
     /**
@@ -55,14 +82,14 @@ class ConfiguredContextFactory implements SerializationContextFactoryInterface, 
      */
     private function configureContext(Context $context)
     {
-        foreach ($this->config['attributes'] as $key => $value) {
+        foreach ($this->attributes as $key => $value) {
             $context->setAttribute($key, $value);
         }
 
-        $context->setGroups($this->config['groups']);
-        $context->setSerializeNull($this->config['serialize_null']);
-        if ($this->config['version'] !== null) {
-            $context->setVersion($this->config['version']);
+        $context->setGroups($this->groups);
+        $context->setSerializeNull($this->serializeNulls);
+        if ($this->version !== null) {
+            $context->setVersion($this->version);
         }
 
         return $context;

--- a/ContextFactory/ConfiguredContextFactory.php
+++ b/ContextFactory/ConfiguredContextFactory.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace JMS\SerializerBundle\ContextFactory;
+
+use JMS\Serializer\Context;
+use JMS\Serializer\ContextFactory\DeserializationContextFactoryInterface;
+use JMS\Serializer\ContextFactory\SerializationContextFactoryInterface;
+use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\SerializationContext;
+
+/**
+ * Class ConfiguredContextFactory
+ */
+class ConfiguredContextFactory implements SerializationContextFactoryInterface, DeserializationContextFactoryInterface
+{
+    /**
+     * Context config
+     *
+     * @var array
+     */
+    private $config;
+
+    /**
+     * ConfiguredContextFactory constructor.
+     *
+     * @param array $config Context configuration
+     */
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createDeserializationContext()
+    {
+        return $this->configureContext(new DeserializationContext());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createSerializationContext()
+    {
+        return $this->configureContext(new SerializationContext());
+    }
+
+    /**
+     * Configures context according to configuration
+     *
+     * @param Context $context The context
+     *
+     * @return Context Given object
+     */
+    private function configureContext(Context $context)
+    {
+        foreach ($this->config['attributes'] as $key => $value) {
+            $context->setAttribute($key, $value);
+        }
+
+        $context->setGroups($this->config['groups']);
+        $context->setSerializeNull($this->config['serialize_null']);
+        if ($this->config['version'] !== null) {
+            $context->setVersion($this->config['version']);
+        }
+
+        return $context;
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -213,8 +213,18 @@ class Configuration implements ConfigurationInterface
 
     private function addContextSection(NodeBuilder $builder)
     {
+        $root = $builder
+                    ->arrayNode('default_context')
+                    ->addDefaultsIfNotSet();
+
+        $this->createContextNode($root->children(), 'serialization');
+        $this->createContextNode($root->children(), 'deserialization');
+    }
+
+    private function createContextNode(NodeBuilder $builder, $name)
+    {
         $builder
-            ->arrayNode('context')
+            ->arrayNode($name)
                 ->addDefaultsIfNotSet()
                 ->children()
                     ->booleanNode('serialize_null')
@@ -239,27 +249,9 @@ class Configuration implements ConfigurationInterface
                     ->end()
                     ->scalarNode('version')
                         ->defaultNull()
-                        ->validate()
-                            ->always(function ($value) {
-                                if ($value === null) {
-                                    return null;
-                                }
-
-                                if (!is_string($value)) {
-                                    throw new InvalidArgumentException('Version must be a string.');
-                                }
-
-                                if (!preg_match('#\d+\.\d+\.\d+#', $value)) {
-                                    throw new InvalidArgumentException('Version must follow semantic versioning format.');
-                                }
-
-                                return $value;
-                            })
-                        ->end()
                         ->info('Application version to use in exclusion strategies')
                     ->end()
                 ->end()
-            ->end()
-        ;
+            ->end();
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,7 +19,6 @@
 namespace JMS\SerializerBundle\DependencyInjection;
 
 use JMS\Serializer\Exception\InvalidArgumentException;
-use JMS\Serializer\Exclusion\GroupsExclusionStrategy;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -80,6 +79,12 @@ class Configuration implements ConfigurationInterface
         $builder
             ->arrayNode('property_naming')
                 ->addDefaultsIfNotSet()
+                ->beforeNormalization()
+                    ->ifString()
+                    ->then(function ($id) {
+                        return array('id' => $id);
+                    })
+                ->end()
                 ->children()
                     ->scalarNode('id')->cannotBeEmpty()->end()
                     ->scalarNode('separator')->defaultValue('_')->end()
@@ -89,6 +94,12 @@ class Configuration implements ConfigurationInterface
             ->end()
             ->arrayNode('expression_evaluator')
                 ->addDefaultsIfNotSet()
+                ->beforeNormalization()
+                    ->ifString()
+                    ->then(function ($id) {
+                        return array('id' => $id);
+                    })
+                ->end()
                 ->children()
                     ->scalarNode('id')
                         ->defaultValue(function () {
@@ -99,7 +110,7 @@ class Configuration implements ConfigurationInterface
                         })
                         ->validate()
                             ->always(function($v) {
-                                if (!empty($v) && !class_exists('Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface')) {
+                                if (!empty($v) && !interface_exists('Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface')) {
                                     throw new InvalidArgumentException('You need at least symfony/expression language v2.6 or v3.0 to use the expression evaluator features');
                                 }
                                 return $v;
@@ -226,13 +237,19 @@ class Configuration implements ConfigurationInterface
     {
         $builder
             ->arrayNode($name)
+                ->addDefaultsIfNotSet()
+                ->beforeNormalization()
+                    ->ifString()
+                    ->then(function ($id) {
+                        return array('id' => $id);
+                    })
+                ->end()
                 ->validate()->always(function ($v) {
                     if (!empty($v['id'])) {
                         return array('id' => $v['id']);
                     }
                     return $v;
                 })->end()
-                ->addDefaultsIfNotSet()
                 ->children()
                     ->scalarNode('id')->cannotBeEmpty()->end()
                     ->scalarNode('serialize_null')

--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -18,13 +18,13 @@
 
 namespace JMS\SerializerBundle\DependencyInjection;
 
-use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
-use Symfony\Component\DependencyInjection\Alias;
 use JMS\Serializer\Exception\RuntimeException;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
 class JMSSerializerExtension extends ConfigurableExtension
 {
@@ -80,10 +80,8 @@ class JMSSerializerExtension extends ConfigurableExtension
             ;
 
             $dir = $container->getParameterBag()->resolveValue($config['metadata']['file_cache']['dir']);
-            if (!file_exists($dir)) {
-                if (!$rs = @mkdir($dir, 0777, true)) {
-                    throw new RuntimeException(sprintf('Could not create cache directory "%s".', $dir));
-                }
+            if (!is_dir($dir) && !@mkdir($dir, 0777, true) && !is_dir($dir)) {
+                throw new RuntimeException(sprintf('Could not create cache directory "%s".', $dir));
             }
         } else {
             $container->setAlias('jms_serializer.metadata.cache', new Alias($config['metadata']['cache'], false));
@@ -140,6 +138,10 @@ class JMSSerializerExtension extends ConfigurableExtension
         if ( ! $container->getParameter('kernel.debug')) {
             $container->removeDefinition('jms_serializer.stopwatch_subscriber');
         }
+
+        // context factories
+        $container->getDefinition('jms_serializer.context_factory')
+            ->replaceArgument(0, $config['context']);
     }
 
     public function getConfiguration(array $config, ContainerBuilder $container)

--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -140,8 +140,18 @@ class JMSSerializerExtension extends ConfigurableExtension
         }
 
         // context factories
-        $container->getDefinition('jms_serializer.context_factory')
-            ->replaceArgument(0, $config['context']);
+        $services = [
+            'serialization' => 'jms_serializer.serialization_context_factory',
+            'deserialization' => 'jms_serializer.deserialization_context_factory',
+        ];
+        foreach ($services as $configKey => $serviceId) {
+            $container->getDefinition($serviceId)
+                      ->replaceArgument(0, $config['default_context'][$configKey]['version'])
+                      ->replaceArgument(1, $config['default_context'][$configKey]['serialize_null'])
+                      ->replaceArgument(2, $config['default_context'][$configKey]['attributes'])
+                      ->replaceArgument(3, $config['default_context'][$configKey]['groups'])
+            ;
+        }
     }
 
     public function getConfiguration(array $config, ContainerBuilder $container)

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -53,8 +53,7 @@
         <parameter key="jms_serializer.doctrine_proxy_subscriber.class">JMS\Serializer\EventDispatcher\Subscriber\DoctrineProxySubscriber</parameter>
         <parameter key="jms_serializer.stopwatch_subscriber.class">JMS\SerializerBundle\Serializer\StopwatchEventSubscriber</parameter>
 
-        <parameter key="jms_serializer.context_factory.serialization.class">JMS\Serializer\ContextFactory\DefaultSerializationContextFactory</parameter>
-        <parameter key="jms_serializer.context_factory.deserialization.class">JMS\Serializer\ContextFactory\DefaultDeserializationContextFactory</parameter>
+        <parameter key="jms_serializer.context_factory.class">JMS\SerializerBundle\ContextFactory\ConfiguredContextFactory</parameter>
 
         <parameter key="jms_serializer.expression_evaluator.class">JMS\Serializer\Expression\ExpressionEvaluator</parameter>
         <parameter key="jms_serializer.expression_language.class">Symfony\Component\ExpressionLanguage\ExpressionLanguage</parameter>
@@ -188,10 +187,10 @@
             <argument type="constant">NULL</argument> <!-- expression evaluator -->
 
             <call method="setSerializationContextFactory">
-                <argument type="service" id="jms_serializer.serialization_context_factory" />
+                <argument type="service" id="jms_serializer.context_factory" />
             </call>
             <call method="setDeserializationContextFactory">
-                <argument type="service" id="jms_serializer.deserialization_context_factory" />
+                <argument type="service" id="jms_serializer.context_factory" />
             </call>
 
         </service>
@@ -268,8 +267,9 @@
         </service>
 
         <!-- context factories -->
-        <service id="jms_serializer.serialization_context_factory" class="%jms_serializer.context_factory.serialization.class%"/>
-        <service id="jms_serializer.deserialization_context_factory" class="%jms_serializer.context_factory.deserialization.class%"/>
+        <service id="jms_serializer.context_factory" class="%jms_serializer.context_factory.class%">
+            <argument type="collection" /> <!-- Configuration settings -->
+        </service>
 
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -187,10 +187,10 @@
             <argument type="constant">NULL</argument> <!-- expression evaluator -->
 
             <call method="setSerializationContextFactory">
-                <argument type="service" id="jms_serializer.context_factory" />
+                <argument type="service" id="jms_serializer.serialization_context_factory" />
             </call>
             <call method="setDeserializationContextFactory">
-                <argument type="service" id="jms_serializer.context_factory" />
+                <argument type="service" id="jms_serializer.deserialization_context_factory" />
             </call>
 
         </service>
@@ -267,9 +267,21 @@
         </service>
 
         <!-- context factories -->
-        <service id="jms_serializer.context_factory" class="%jms_serializer.context_factory.class%">
-            <argument type="collection" /> <!-- Configuration settings -->
+        <service id="jms_serializer.abstract_context_factory"
+                 class="%jms_serializer.context_factory.class%"
+                 abstract="true"
+                 public="false">
+            <argument /> <!-- Version -->
+            <argument /> <!-- Serialize nulls -->
+            <argument type="collection"/> <!-- Custom attributes -->
+            <argument type="collection"/> <!-- Serialization groups -->
         </service>
 
+        <service id="jms_serializer.serialization_context_factory"
+                 class="%jms_serializer.context_factory.class%"
+                 parent="jms_serializer.abstract_context_factory" />
+        <service id="jms_serializer.deserialization_context_factory"
+                 class="%jms_serializer.context_factory.class%"
+                 parent="jms_serializer.abstract_context_factory" />
     </services>
 </container>

--- a/Tests/ContextFactory/ConfiguredContextFactoryTest.php
+++ b/Tests/ContextFactory/ConfiguredContextFactoryTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace JMS\SerializerBundle\Tests\ContextFactory;
+
+use JMS\SerializerBundle\ContextFactory\ConfiguredContextFactory;
+
+/**
+ * Class ConfiguredContextFactoryTest
+ */
+class ConfiguredContextFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreateSerializationContext()
+    {
+        $config = $this->getContextConfig();
+        $object = new ConfiguredContextFactory($config);
+
+        $this->assertInstanceOf('JMS\Serializer\ContextFactory\SerializationContextFactoryInterface', $object);
+
+        $context = $object->createSerializationContext();
+        $this->assertInstanceOf('JMS\Serializer\SerializationContext', $context);
+        $this->assertSame($config['serialize_null'], $context->shouldSerializeNull());
+
+        $this->assertSame($config['version'], $context->attributes->get('version')->get());
+        $this->assertSame($config['groups'], $context->attributes->get('groups')->get());
+    }
+
+    public function testCreateDeserializationContext()
+    {
+        $config = $this->getContextConfig();
+        $object = new ConfiguredContextFactory($config);
+
+        $this->assertInstanceOf('JMS\Serializer\ContextFactory\DeserializationContextFactoryInterface', $object);
+
+        $context = $object->createDeserializationContext();
+        $this->assertInstanceOf('JMS\Serializer\DeserializationContext', $context);
+        $this->assertSame($config['serialize_null'], $context->shouldSerializeNull());
+
+        $this->assertSame($config['version'], $context->attributes->get('version')->get());
+        $this->assertSame($config['groups'], $context->attributes->get('groups')->get());
+    }
+
+    private function getContextConfig()
+    {
+        return [
+            'attributes'     => [
+                'x' => mt_rand(0, PHP_INT_MAX),
+            ],
+            'groups'         => [ 'Default', 'Registration' ],
+            'serialize_null' => true,
+            'version'        => sprintf('%d.%d.%d', mt_rand(1, 10), mt_rand(1, 10), mt_rand(1, 10)),
+        ];
+    }
+}

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -18,7 +18,9 @@
 
 namespace JMS\SerializerBundle\Tests\DependencyInjection;
 
+use JMS\SerializerBundle\DependencyInjection\Configuration;
 use JMS\SerializerBundle\JMSSerializerBundle;
+use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ConfigurationTest extends \PHPUnit_Framework_TestCase
@@ -63,5 +65,22 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($ref->getPath(), $directories['JMSSerializerBundleNs1']);
         $this->assertEquals($ref->getPath().'/Resources/config', $directories['JMSSerializerBundleNs2']);
+    }
+
+    public function testContextDefaults()
+    {
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new Configuration(true), []);
+
+        $this->assertArrayHasKey('context', $config);
+        $this->assertArrayHasKey('attributes', $config['context']);
+        $this->assertTrue(is_array($config['context']['attributes']));
+        $this->assertEmpty($config['context']['attributes']);
+        $this->assertArrayHasKey('groups', $config['context']);
+        $this->assertSame(['Default'], $config['context']['groups']);
+        $this->assertArrayHasKey('version', $config['context']);
+        $this->assertNull($config['context']['version']);
+        $this->assertArrayHasKey('serialize_null', $config['context']);
+        $this->assertFalse($config['context']['serialize_null']);
     }
 }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -72,15 +72,21 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $processor = new Processor();
         $config = $processor->processConfiguration(new Configuration(true), []);
 
-        $this->assertArrayHasKey('context', $config);
-        $this->assertArrayHasKey('attributes', $config['context']);
-        $this->assertTrue(is_array($config['context']['attributes']));
-        $this->assertEmpty($config['context']['attributes']);
-        $this->assertArrayHasKey('groups', $config['context']);
-        $this->assertSame(['Default'], $config['context']['groups']);
-        $this->assertArrayHasKey('version', $config['context']);
-        $this->assertNull($config['context']['version']);
-        $this->assertArrayHasKey('serialize_null', $config['context']);
-        $this->assertFalse($config['context']['serialize_null']);
+        $this->assertArrayHasKey('default_context', $config);
+        foreach (['serialization', 'deserialization'] as $item) {
+            $this->assertArrayHasKey($item, $config['default_context']);
+
+            $defaultContext = $config['default_context'][$item];
+            $this->assertArrayHasKey('attributes', $defaultContext);
+            $this->assertTrue(is_array($defaultContext['attributes']));
+            $this->assertEmpty($defaultContext['attributes']);
+            $this->assertArrayHasKey('groups', $defaultContext);
+            $this->assertSame(['Default'], $defaultContext['groups']);
+            $this->assertArrayHasKey('version', $defaultContext);
+            $this->assertNull($defaultContext['version']);
+            $this->assertArrayHasKey('serialize_null', $defaultContext);
+            $this->assertFalse($defaultContext['serialize_null']);
+        }
+
     }
 }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -127,6 +127,39 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testConfigNormalization()
+    {
+        $configArray = [
+            'default_context' => [
+                'serialization' => 'the.serialization.factory.context',
+                'deserialization' => 'the.deserialization.factory.context',
+            ],
+            'property_naming' => 'property.mapping.service',
+            'expression_evaluator' => 'expression_evaluator.service',
+        ];
+
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new Configuration(true), [
+            'jms_serializer' => $configArray
+        ]);
+
+        $this->assertArrayHasKey('default_context', $config);
+        $this->assertArrayHasKey('serialization', $config['default_context']);
+        $this->assertArrayHasKey('deserialization', $config['default_context']);
+        $this->assertArrayHasKey('id', $config['default_context']['serialization']);
+        $this->assertArrayHasKey('id', $config['default_context']['deserialization']);
+
+        $this->assertSame($configArray['default_context']['serialization'], $config['default_context']['serialization']['id']);
+        $this->assertSame($configArray['default_context']['deserialization'], $config['default_context']['deserialization']['id']);
+
+        $this->assertArrayHasKey('property_naming', $config);
+        $this->assertArrayHasKey('expression_evaluator', $config);
+        $this->assertArrayHasKey('id', $config['property_naming']);
+        $this->assertArrayHasKey('id', $config['expression_evaluator']);
+        $this->assertSame($configArray['property_naming'], $config['property_naming']['id']);
+        $this->assertSame($configArray['expression_evaluator'], $config['expression_evaluator']['id']);
+    }
+
     public function testContextNullValues()
     {
         $configArray = array(

--- a/Tests/DependencyInjection/JMSSerializerExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSerializerExtensionTest.php
@@ -333,6 +333,9 @@ class JMSSerializerExtensionTest extends \PHPUnit_Framework_TestCase
      */
     public function testExpressionInvalidEvaluator()
     {
+        if (is_dir(__DIR__ . '/../../vendor/symfony/expression-language')) {
+            $this->markTestSkipped('To pass this test the "symfony/expression-language" component should be removed');
+        }
         $this->getContainerForConfig(array(array('expression_evaluator' => array('id' => 'foo'))));
     }
 

--- a/Tests/ExpressionLanguage/ExpressionLanguageTest.php
+++ b/Tests/ExpressionLanguage/ExpressionLanguageTest.php
@@ -42,7 +42,7 @@ class ExpressionLanguageTest extends \PHPUnit_Framework_TestCase
         $exp = new ExpressionLanguage();
         $exp->registerProvider($provider);
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container
             ->expects($this->once())
             ->method('get')->with('foo', 1)
@@ -50,7 +50,7 @@ class ExpressionLanguageTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('bar', $exp->evaluate("service('foo')", ['container' => $container]));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container
             ->expects($this->once())
             ->method('getParameter')->with('foo')
@@ -58,14 +58,14 @@ class ExpressionLanguageTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('bar', $exp->evaluate("parameter('foo')", ['container' => $container]));
 
-        $authChecker = $this->getMock('JMS\SerializerBundle\Tests\ExpressionLanguage\AuthCheckerMock');
+        $authChecker = $this->getMockBuilder('JMS\SerializerBundle\Tests\ExpressionLanguage\AuthCheckerMock')->getMock();
         $authChecker
             ->expects($this->once())
             ->method('isGranted')->with('foo')
             ->will($this->returnValue('bar'));
 
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container
             ->expects($this->once())
             ->method('get')->with('security.authorization_checker')


### PR DESCRIPTION
This PR adds functionality for setting up default context parameters for serializer via configuration:
```yaml
jms_serializer:
  default_context:
    serialization:
      serialize_null: false
      version: ~ 
      attributes: {}
      groups: ['Default']
    deserialization:
      serialize_null: false
      version: ~ 
      attributes: {}
      groups: ['Default']
```
Also this PR fixes deprecation warnings in tests.