### PR TITLE
Added runtime twig extension support (significant performance improvements)

### DIFF
--- a/DependencyInjection/Compiler/TwigExtensionPass.php
+++ b/DependencyInjection/Compiler/TwigExtensionPass.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace JMS\SerializerBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class TwigExtensionPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('twig.runtime_loader')
+            || !class_exists($container->getParameter('jms_serializer.twig_runtime_extension.class'))
+            || !interface_exists('Twig_RuntimeLoaderInterface')
+            || !class_exists($container->getParameter('jms_serializer.twig_runtime_extension_helper.class'))
+        ) {
+            $container->removeDefinition('jms_serializer.twig_extension.serializer_runtime_helper');
+            return;
+        }
+
+        $def = $container->getDefinition('jms_serializer.twig_extension.serializer');
+        $def->setClass('%jms_serializer.twig_runtime_extension.class%');
+        $def->setArguments(array());
+    }
+}

--- a/JMSSerializerBundle.php
+++ b/JMSSerializerBundle.php
@@ -19,6 +19,7 @@
 namespace JMS\SerializerBundle;
 
 use JMS\SerializerBundle\DependencyInjection\Compiler\DoctrinePass;
+use JMS\SerializerBundle\DependencyInjection\Compiler\TwigExtensionPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use JMS\SerializerBundle\DependencyInjection\Compiler\CustomHandlersPass;
 use JMS\SerializerBundle\DependencyInjection\Compiler\RegisterEventListenersAndSubscribersPass;
@@ -43,6 +44,7 @@ class JMSSerializerBundle extends Bundle
             }
         ));
 
+        $builder->addCompilerPass(new TwigExtensionPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION);
         $builder->addCompilerPass(new RegisterEventListenersAndSubscribersPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $builder->addCompilerPass(new CustomHandlersPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $builder->addCompilerPass(new DoctrinePass(), PassConfig::TYPE_BEFORE_REMOVING);

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -33,6 +33,8 @@
         <parameter key="jms_serializer.serializer.class">JMS\Serializer\Serializer</parameter>
 
         <parameter key="jms_serializer.twig_extension.class">JMS\Serializer\Twig\SerializerExtension</parameter>
+        <parameter key="jms_serializer.twig_runtime_extension.class">JMS\Serializer\Twig\SerializerRuntimeExtension</parameter>
+        <parameter key="jms_serializer.twig_runtime_extension_helper.class">JMS\Serializer\Twig\SerializerRuntimeHelper</parameter>
         <parameter key="jms_serializer.templating.helper.class">JMS\SerializerBundle\Templating\SerializerHelper</parameter>
 
         <parameter key="jms_serializer.json_serialization_visitor.class">JMS\Serializer\JsonSerializationVisitor</parameter>
@@ -220,6 +222,11 @@
         <service id="jms_serializer.twig_extension.serializer" class="%jms_serializer.twig_extension.class%" public="false">
             <argument type="service" id="jms_serializer" />
             <tag name="twig.extension" />
+        </service>
+
+        <service id="jms_serializer.twig_extension.serializer_runtime_helper" class="%jms_serializer.twig_runtime_extension_helper.class%" public="true">
+            <argument type="service" id="jms_serializer" />
+            <tag name="twig.runtime" />
         </service>
 
         <!-- PHP templating helper -->

--- a/Tests/DependencyInjection/TwigExtensionPassTest.php
+++ b/Tests/DependencyInjection/TwigExtensionPassTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\SerializerBundle\Tests\DependencyInjection;
+
+use JMS\SerializerBundle\DependencyInjection\Compiler\TwigExtensionPass;
+use JMS\SerializerBundle\DependencyInjection\JMSSerializerExtension;
+use Symfony\Component\DependencyInjection\Compiler\RemoveUnusedDefinitionsPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class TwigExtensionPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return ContainerBuilder
+     */
+    private function getContainer()
+    {
+        $loader = new JMSSerializerExtension();
+        $container = new ContainerBuilder();
+
+        $container->getCompilerPassConfig()->setOptimizationPasses(array(
+            new ResolveParameterPlaceHoldersPass(),
+            new ResolveDefinitionTemplatesPass(),
+        ));
+        $container->getCompilerPassConfig()->setRemovingPasses(array(new RemoveUnusedDefinitionsPass()));
+
+        $container->setParameter('kernel.debug', true);
+        $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/serializer');
+        $container->setParameter('kernel.bundles', array());
+
+        $loader->load([[]], $container);
+        return $container;
+    }
+
+    public function testStandardExtension()
+    {
+        $container = $this->getContainer();
+
+        $pass = new TwigExtensionPass();
+        $pass->process($container);
+
+        $extension = $container->getDefinition('jms_serializer.twig_extension.serializer');
+        $this->assertEquals('%jms_serializer.twig_extension.class%', (string)$extension->getClass());
+        $this->assertCount(1, $extension->getArguments());
+
+        $this->assertFalse($container->hasDefinition('jms_serializer.twig_extension.serializer_runtime_helper'));
+    }
+
+    public function testLazyExtension()
+    {
+        if (!class_exists('JMS\Serializer\Twig\SerializerRuntimeExtension')) {
+            $this->markTestSkipped("Lazy extensions are supported only by serializer 1.7.0");
+        }
+        $container = $this->getContainer();
+
+        $container->register('twig.runtime_loader');
+
+        $pass = new TwigExtensionPass();
+        $pass->process($container);
+
+        $extension = $container->getDefinition('jms_serializer.twig_extension.serializer');
+        $this->assertEquals('%jms_serializer.twig_runtime_extension.class%', (string)$extension->getClass());
+        $this->assertCount(0, $extension->getArguments());
+
+        $this->assertTrue($container->hasDefinition('jms_serializer.twig_extension.serializer_runtime_helper'));
+    }
+
+    public function testLazyExtensionNotLoadedWhenOldSerializer()
+    {
+        $container = $this->getContainer();
+
+        $container->getParameterBag()->add(array(
+            'jms_serializer.twig_runtime_extension.class' => 'foo',
+            'jms_serializer.twig_runtime_extension_helper.class' => 'bar',
+        ));
+
+        $container->register('twig.runtime_loader');
+
+        $pass = new TwigExtensionPass();
+        $pass->process($container);
+
+        $extension = $container->getDefinition('jms_serializer.twig_extension.serializer');
+        $this->assertEquals('%jms_serializer.twig_extension.class%', (string)$extension->getClass());
+        $this->assertCount(1, $extension->getArguments());
+
+        $this->assertFalse($container->hasDefinition('jms_serializer.twig_extension.serializer_runtime_helper'));
+    }
+}
+

--- a/Tests/DependencyInjection/TwigExtensionPassTest.php
+++ b/Tests/DependencyInjection/TwigExtensionPassTest.php
@@ -65,7 +65,10 @@ class TwigExtensionPassTest extends \PHPUnit_Framework_TestCase
 
     public function testLazyExtension()
     {
-        if (!class_exists('JMS\Serializer\Twig\SerializerRuntimeExtension')) {
+        if (
+            !class_exists('JMS\Serializer\Twig\SerializerRuntimeExtension')
+            || !interface_exists('Twig_RuntimeLoaderInterface')
+        ) {
             $this->markTestSkipped("Lazy extensions are supported only by serializer 1.7.0");
         }
         $container = $this->getContainer();

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "jms/serializer": "twig-runtime-loader-dev as 1.7.0",
+        "jms/serializer": "^1.7@DEV",
         "phpoption/phpoption": "^1.1.0",
         "symfony/framework-bundle": "~2.3|~3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "jms/serializer": "^1.6",
+        "jms/serializer": "twig-runtime-loader-dev as 1.7.0",
         "phpoption/phpoption": "^1.1.0",
         "symfony/framework-bundle": "~2.3|~3.0"
     },


### PR DESCRIPTION
Fixes https://github.com/schmittjoh/JMSSerializerBundle/issues/562

requires https://github.com/schmittjoh/serializer/pull/747 (probably jms serializer 1.7), twig 1.26 and symfony 3.2