### PR TITLE
Add missing dev dependency on "symfony/translator"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "doctrine/orm": "*",
         "symfony/form": "*",
         "symfony/validator": "*",
-        "symfony/stopwatch": "*"
+        "symfony/stopwatch": "*",
+        "symfony/translator": "*"
     },
     "suggest": {
         "jms/di-extra-bundle": "Required to get lazy loading (de)serialization visitors, ~1.3"


### PR DESCRIPTION
Service "jms_serializer.form_error_handler" depends on "symfony/translator" which makes building container fail.

<details>

```
'Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException' with message 'The service "jms_serializer.form_error_handler" has a dependency on a non-existent service "translator".'
```

</details>