### PR TITLE
Allow autowiring serializer

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -200,6 +200,7 @@
         <service id="jms_serializer.serialization_context_factory" alias="jms_serializer.configured_serialization_context_factory"/>
 
         <service id="jms_serializer" alias="jms_serializer.serializer" /><!-- Preferred Alias -->
+        <service id="JMS\Serializer\SerializerInterface" alias="jms_serializer.serializer" />
         <service id="serializer" alias="jms_serializer.serializer" /><!-- Here for BC, may be disabled in the config -->
 
         <!-- expression language components -->

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -201,6 +201,7 @@
 
         <service id="jms_serializer" alias="jms_serializer.serializer" /><!-- Preferred Alias -->
         <service id="JMS\Serializer\SerializerInterface" alias="jms_serializer.serializer" />
+        <service id="JMS\Serializer\ArrayTransformerInterface" alias="jms_serializer.serializer" />
         <service id="serializer" alias="jms_serializer.serializer" /><!-- Here for BC, may be disabled in the config -->
 
         <!-- expression language components -->

--- a/Tests/DependencyInjection/JMSSerializerExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSerializerExtensionTest.php
@@ -223,8 +223,8 @@ class JMSSerializerExtensionTest extends \PHPUnit_Framework_TestCase
         $versionedObject = new VersionedObject('foo', 'bar');
         $serializer = $container->get('serializer');
 
-        $this->assertTrue($container-has('JMS\Serializer\SerializerInterface'), 'Alias should be defined to allow autowiring');
-        $this->assertTrue($container-has('JMS\Serializer\ArrayTransformerInterface'), 'Alias should be defined to allow autowiring');
+        $this->assertTrue($container->has('JMS\Serializer\SerializerInterface'), 'Alias should be defined to allow autowiring');
+        $this->assertTrue($container->has('JMS\Serializer\ArrayTransformerInterface'), 'Alias should be defined to allow autowiring');
         // test that all components have been wired correctly
         $this->assertEquals(json_encode(array('name' => 'bar')), $serializer->serialize($versionedObject, 'json'));
         $this->assertEquals($simpleObject, $serializer->deserialize($serializer->serialize($simpleObject, 'json'), get_class($simpleObject), 'json'));

--- a/Tests/DependencyInjection/JMSSerializerExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSerializerExtensionTest.php
@@ -223,6 +223,8 @@ class JMSSerializerExtensionTest extends \PHPUnit_Framework_TestCase
         $versionedObject = new VersionedObject('foo', 'bar');
         $serializer = $container->get('serializer');
 
+        $this->assertTrue($container-has('JMS\Serializer\SerializerInterface'), 'Alias should be defined to allow autowiring');
+        $this->assertTrue($container-has('JMS\Serializer\ArrayTransformerInterface'), 'Alias should be defined to allow autowiring');
         // test that all components have been wired correctly
         $this->assertEquals(json_encode(array('name' => 'bar')), $serializer->serialize($versionedObject, 'json'));
         $this->assertEquals($simpleObject, $serializer->deserialize($serializer->serialize($simpleObject, 'json'), get_class($simpleObject), 'json'));


### PR DESCRIPTION
To get rid of

> Autowiring services based on the types they implement is deprecated since Symfony 3.3 and won't be supported in version 4.0. You should rename (or alias) the "jms_serializer.serializer" service to "JMS\Serializer\SerializerInterface" instead.

See https://github.com/symfony/symfony/pull/22295 and https://github.com/symfony/symfony/pull/22098