### PR TITLE
compatibility with Symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
       env: SYMFONY_VERSION='2.8'
     - php: 5.6
       env: SYMFONY_VERSION='3.0'
+    - php: 7.1
+      env: SYMFONY_VERSION='~4.0@dev'
     - php: 5.5
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 

--- a/Tests/ContextFactory/ConfiguredContextFactoryTest.php
+++ b/Tests/ContextFactory/ConfiguredContextFactoryTest.php
@@ -4,11 +4,12 @@ namespace JMS\SerializerBundle\Tests\ContextFactory;
 
 use JMS\Serializer\Context;
 use JMS\SerializerBundle\ContextFactory\ConfiguredContextFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ConfiguredContextFactoryTest
  */
-class ConfiguredContextFactoryTest extends \PHPUnit_Framework_TestCase
+class ConfiguredContextFactoryTest extends TestCase
 {
     /**
      * testCreateSerializationContext

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -20,10 +20,11 @@ namespace JMS\SerializerBundle\Tests\DependencyInjection;
 
 use JMS\SerializerBundle\DependencyInjection\Configuration;
 use JMS\SerializerBundle\JMSSerializerBundle;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     private function getContainer(array $configs = array())
     {

--- a/Tests/DependencyInjection/CustomHandlerPassTest.php
+++ b/Tests/DependencyInjection/CustomHandlerPassTest.php
@@ -21,13 +21,14 @@ namespace JMS\SerializerBundle\Tests\DependencyInjection;
 use JMS\Serializer\Exception\RuntimeException;
 use JMS\SerializerBundle\DependencyInjection\Compiler\CustomHandlersPass;
 use JMS\SerializerBundle\DependencyInjection\JMSSerializerExtension;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Compiler\RemoveUnusedDefinitionsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
-class CustomHandlerPassTest extends \PHPUnit_Framework_TestCase
+class CustomHandlerPassTest extends TestCase
 {
     /**
      * @param array $configs

--- a/Tests/DependencyInjection/DoctrinePassTest.php
+++ b/Tests/DependencyInjection/DoctrinePassTest.php
@@ -20,12 +20,13 @@ namespace JMS\SerializerBundle\Tests\DependencyInjection;
 
 use JMS\SerializerBundle\DependencyInjection\Compiler\DoctrinePass;
 use JMS\SerializerBundle\DependencyInjection\JMSSerializerExtension;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Compiler\RemoveUnusedDefinitionsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class DoctrinePassTest extends \PHPUnit_Framework_TestCase
+class DoctrinePassTest extends TestCase
 {
     /**
      *

--- a/Tests/DependencyInjection/EventSubscribersAndListenersPassTest.php
+++ b/Tests/DependencyInjection/EventSubscribersAndListenersPassTest.php
@@ -20,13 +20,14 @@ namespace JMS\SerializerBundle\Tests\DependencyInjection;
 
 use JMS\SerializerBundle\DependencyInjection\Compiler\RegisterEventListenersAndSubscribersPass;
 use JMS\SerializerBundle\DependencyInjection\JMSSerializerExtension;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Compiler\RemoveUnusedDefinitionsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
-class EventSubscribersAndListenersPassTest extends \PHPUnit_Framework_TestCase
+class EventSubscribersAndListenersPassTest extends TestCase
 {
     /**
      * @param array $configs

--- a/Tests/DependencyInjection/JMSSerializerExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSerializerExtensionTest.php
@@ -25,13 +25,14 @@ use JMS\SerializerBundle\Tests\DependencyInjection\Fixture\ObjectUsingExpression
 use JMS\SerializerBundle\Tests\DependencyInjection\Fixture\ObjectUsingExpressionProperties;
 use JMS\SerializerBundle\Tests\DependencyInjection\Fixture\SimpleObject;
 use JMS\SerializerBundle\Tests\DependencyInjection\Fixture\VersionedObject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpKernel\KernelInterface;
 
-class JMSSerializerExtensionTest extends \PHPUnit_Framework_TestCase
+class JMSSerializerExtensionTest extends TestCase
 {
     protected function setUp()
     {

--- a/Tests/DependencyInjection/NamingStrategyTest.php
+++ b/Tests/DependencyInjection/NamingStrategyTest.php
@@ -21,12 +21,13 @@ namespace JMS\SerializerBundle\Tests\DependencyInjection;
 use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 use JMS\SerializerBundle\DependencyInjection\JMSSerializerExtension;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Compiler\RemoveUnusedDefinitionsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class NamingStrategyTest extends \PHPUnit_Framework_TestCase
+class NamingStrategyTest extends TestCase
 {
     /**
      *

--- a/Tests/DependencyInjection/TwigExtensionPassTest.php
+++ b/Tests/DependencyInjection/TwigExtensionPassTest.php
@@ -20,12 +20,13 @@ namespace JMS\SerializerBundle\Tests\DependencyInjection;
 
 use JMS\SerializerBundle\DependencyInjection\Compiler\TwigExtensionPass;
 use JMS\SerializerBundle\DependencyInjection\JMSSerializerExtension;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Compiler\RemoveUnusedDefinitionsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class TwigExtensionPassTest extends \PHPUnit_Framework_TestCase
+class TwigExtensionPassTest extends TestCase
 {
     /**
      * @return ContainerBuilder

--- a/Tests/ExpressionLanguage/ExpressionLanguageTest.php
+++ b/Tests/ExpressionLanguage/ExpressionLanguageTest.php
@@ -19,9 +19,10 @@
 namespace JMS\SerializerBundle\Tests\ExpressionLanguage;
 
 use JMS\SerializerBundle\ExpressionLanguage\BasicSerializerFunctionsProvider;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
-class ExpressionLanguageTest extends \PHPUnit_Framework_TestCase
+class ExpressionLanguageTest extends TestCase
 {
     public function testFunctionProviderCompilation()
     {

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
         "php": ">=5.4.0",
         "jms/serializer": "^1.7",
         "phpoption/phpoption": "^1.1.0",
-        "symfony/framework-bundle": "~2.3|~3.0"
+        "symfony/framework-bundle": "~2.3|~3.0|~4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.2|^5.0",
-        "symfony/expression-language": "~2.6|~3.0",
+        "phpunit/phpunit": "^4.8.35|^5.4.3|^6.0",
+        "symfony/expression-language": "~2.6|~3.0|~4.0",
         "symfony/yaml": "*",
         "symfony/browser-kit": "*",
         "symfony/class-loader": "*",
@@ -37,6 +37,7 @@
         "symfony/validator": "*",
         "symfony/stopwatch": "*"
     },
+    "minimum-stability": "dev",
     "suggest": {
         "jms/di-extra-bundle": "Required to get lazy loading (de)serialization visitors, ~1.3"
     },


### PR DESCRIPTION
In FOSRestBundle, we need this to test for compatibility with Symfony 4 (see FriendsOfSymfony/FOSRestBundle#1708).