### PR TITLE
Injected validator.translation_domain to FormErrorHandler

### DIFF
--- a/DependencyInjection/Compiler/FormErrorHandlerTranslationDomainPass.php
+++ b/DependencyInjection/Compiler/FormErrorHandlerTranslationDomainPass.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\SerializerBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class FormErrorHandlerTranslationDomainPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasParameter('validator.translation_domain')) {
+            return;
+        }
+
+        $container->findDefinition('jms_serializer.form_error_handler')
+            ->addArgument('%validator.translation_domain%');
+    }
+}

--- a/JMSSerializerBundle.php
+++ b/JMSSerializerBundle.php
@@ -21,6 +21,7 @@ namespace JMS\SerializerBundle;
 use JMS\DiExtraBundle\DependencyInjection\Compiler\LazyServiceMapPass;
 use JMS\SerializerBundle\DependencyInjection\Compiler\CustomHandlersPass;
 use JMS\SerializerBundle\DependencyInjection\Compiler\DoctrinePass;
+use JMS\SerializerBundle\DependencyInjection\Compiler\FormErrorHandlerTranslationDomainPass;
 use JMS\SerializerBundle\DependencyInjection\Compiler\RegisterEventListenersAndSubscribersPass;
 use JMS\SerializerBundle\DependencyInjection\Compiler\ServiceMapPass;
 use JMS\SerializerBundle\DependencyInjection\Compiler\TwigExtensionPass;
@@ -44,6 +45,7 @@ class JMSSerializerBundle extends Bundle
             }
         ));
 
+        $builder->addCompilerPass(new FormErrorHandlerTranslationDomainPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION);
         $builder->addCompilerPass(new TwigExtensionPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION);
         $builder->addCompilerPass(new RegisterEventListenersAndSubscribersPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $builder->addCompilerPass(new CustomHandlersPass(), PassConfig::TYPE_BEFORE_REMOVING);

--- a/Tests/DependencyInjection/FormErrorHandlerTranslationDomainPassTest.php
+++ b/Tests/DependencyInjection/FormErrorHandlerTranslationDomainPassTest.php
@@ -21,8 +21,9 @@ namespace JMS\SerializerBundle\Tests\DependencyInjection;
 use JMS\SerializerBundle\DependencyInjection\Compiler\FormErrorHandlerTranslationDomainPass;
 use JMS\SerializerBundle\DependencyInjection\JMSSerializerExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use use PHPUnit\Framework\TestCase;
 
-class FormErrorHandlerTranslationDomainPassTest extends \PHPUnit_Framework_TestCase
+class FormErrorHandlerTranslationDomainPassTest extends TestCase
 {
     /**
      * @param array $configs

--- a/Tests/DependencyInjection/FormErrorHandlerTranslationDomainPassTest.php
+++ b/Tests/DependencyInjection/FormErrorHandlerTranslationDomainPassTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\SerializerBundle\Tests\DependencyInjection;
+
+use JMS\SerializerBundle\DependencyInjection\Compiler\FormErrorHandlerTranslationDomainPass;
+use JMS\SerializerBundle\DependencyInjection\JMSSerializerExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class FormErrorHandlerTranslationDomainPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param array $configs
+     *
+     * @return ContainerBuilder
+     */
+    private function getContainer(array $configs = array())
+    {
+        $loader = new JMSSerializerExtension();
+        $container = new ContainerBuilder();
+
+        $container->setParameter('kernel.debug', true);
+        $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/serializer');
+        $container->setParameter('kernel.bundles', array());
+
+        $loader->load(['jms_serializer' => $configs], $container);
+
+        return $container;
+    }
+
+    public function testExistentParameter()
+    {
+        $container = $this->getContainer();
+        $container->setParameter('validator.translation_domain', 'custom_domain');
+
+        $pass = new FormErrorHandlerTranslationDomainPass();
+        $pass->process($container);
+
+        $args = $container->findDefinition('jms_serializer.form_error_handler')->getArguments();
+
+        $this->assertArrayHasKey(1, $args);
+        $this->assertContains('%validator.translation_domain%', $args[1]);
+    }
+
+    public function testNonExistentParameter()
+    {
+        $container = $this->getContainer();
+
+        $pass = new FormErrorHandlerTranslationDomainPass();
+        $pass->process($container);
+
+        $args = $container->findDefinition('jms_serializer.form_error_handler')->getArguments();
+
+        $this->assertArrayNotHasKey(1, $args);
+    }
+}

--- a/Tests/DependencyInjection/FormErrorHandlerTranslationDomainPassTest.php
+++ b/Tests/DependencyInjection/FormErrorHandlerTranslationDomainPassTest.php
@@ -21,7 +21,7 @@ namespace JMS\SerializerBundle\Tests\DependencyInjection;
 use JMS\SerializerBundle\DependencyInjection\Compiler\FormErrorHandlerTranslationDomainPass;
 use JMS\SerializerBundle\DependencyInjection\JMSSerializerExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class FormErrorHandlerTranslationDomainPassTest extends TestCase
 {


### PR DESCRIPTION
Injected translation domain parameter (validator.translation_domain) to FormErrorHandler. This is a solution suggestion for the following issue: https://github.com/schmittjoh/JMSSerializerBundle/issues/501 and https://github.com/schmittjoh/serializer/pull/783