### PR TITLE
Improve the autowiring configuration

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -206,8 +206,8 @@
         <service id="jms_serializer.serialization_context_factory" alias="jms_serializer.configured_serialization_context_factory"/>
 
         <service id="jms_serializer" alias="jms_serializer.serializer" /><!-- Preferred Alias -->
-        <service id="JMS\Serializer\SerializerInterface" alias="jms_serializer.serializer" />
-        <service id="JMS\Serializer\ArrayTransformerInterface" alias="jms_serializer.serializer" />
+        <service id="JMS\Serializer\SerializerInterface" alias="jms_serializer" public="false" />
+        <service id="JMS\Serializer\ArrayTransformerInterface" alias="jms_serializer" public="false" />
 
 
         <!-- expression language components -->


### PR DESCRIPTION
- autowiring aliases should be private, as there is no reason to expose these ids at runtime (autowiring needs them at compile time only)
- autowiring aliases should point to the preferred alias rather than to the actual service, to be compatible with services deciding to decorate the serializer using the preferred alias (which is the id they know)