### PR TITLE
[Composer] Upgrade required php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }        
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": "^5.5|^7.0",
         "jms/serializer": "^1.7",
         "phpoption/phpoption": "^1.1.0",
         "symfony/framework-bundle": "~2.3|~3.0"


### PR DESCRIPTION
`jms/serializer` requires PHP version > 5.5 anyway, so it could be adjusted on bundle as well. Also, as a proposal, I have changed `>=` to `^`, because it is more semantically correct. You cannot prove that this bundle will work with PHP 8.0