### PR TITLE
Remove dependencies from translator and form handler

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -96,7 +96,7 @@
             <tag name="jms_serializer.subscribing_handler" />
         </service>
         <service id="jms_serializer.form_error_handler" class="%jms_serializer.form_error_handler.class%">
-            <argument type="service" id="translator" />
+            <argument type="service" id="translator" on-invalid="null" />
             <tag name="jms_serializer.subscribing_handler" />
         </service>
         <service id="jms_serializer.constraint_violation_handler" class="%jms_serializer.constraint_violation_handler.class%">

--- a/Tests/DependencyInjection/CustomHandlerPassTest.php
+++ b/Tests/DependencyInjection/CustomHandlerPassTest.php
@@ -22,9 +22,6 @@ use JMS\Serializer\Exception\RuntimeException;
 use JMS\SerializerBundle\DependencyInjection\Compiler\CustomHandlersPass;
 use JMS\SerializerBundle\DependencyInjection\JMSSerializerExtension;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\Compiler\RemoveUnusedDefinitionsPass;
-use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
-use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -39,12 +36,6 @@ class CustomHandlerPassTest extends TestCase
     {
         $loader = new JMSSerializerExtension();
         $container = new ContainerBuilder();
-
-        $container->getCompilerPassConfig()->setOptimizationPasses(array(
-            new ResolveParameterPlaceHoldersPass(),
-            new ResolveDefinitionTemplatesPass(),
-        ));
-        $container->getCompilerPassConfig()->setRemovingPasses(array(new RemoveUnusedDefinitionsPass()));
 
         $container->setParameter('kernel.debug', true);
         $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/serializer');

--- a/Tests/DependencyInjection/DoctrinePassTest.php
+++ b/Tests/DependencyInjection/DoctrinePassTest.php
@@ -21,9 +21,6 @@ namespace JMS\SerializerBundle\Tests\DependencyInjection;
 use JMS\SerializerBundle\DependencyInjection\Compiler\DoctrinePass;
 use JMS\SerializerBundle\DependencyInjection\JMSSerializerExtension;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\Compiler\RemoveUnusedDefinitionsPass;
-use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
-use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class DoctrinePassTest extends TestCase
@@ -37,13 +34,6 @@ class DoctrinePassTest extends TestCase
     {
         $loader = new JMSSerializerExtension();
         $container = new ContainerBuilder();
-
-
-        $container->getCompilerPassConfig()->setOptimizationPasses(array(
-            new ResolveParameterPlaceHoldersPass(),
-            new ResolveDefinitionTemplatesPass(),
-        ));
-        $container->getCompilerPassConfig()->setRemovingPasses(array(new RemoveUnusedDefinitionsPass()));
 
         $container->setParameter('kernel.debug', true);
         $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/serializer');

--- a/Tests/DependencyInjection/EventSubscribersAndListenersPassTest.php
+++ b/Tests/DependencyInjection/EventSubscribersAndListenersPassTest.php
@@ -22,9 +22,6 @@ use JMS\SerializerBundle\DependencyInjection\Compiler\RegisterEventListenersAndS
 use JMS\SerializerBundle\DependencyInjection\JMSSerializerExtension;
 use JMS\SerializerBundle\Tests\DependencyInjection\Fixture\SimpleHandler;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\Compiler\RemoveUnusedDefinitionsPass;
-use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
-use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
@@ -38,12 +35,6 @@ class EventSubscribersAndListenersPassTest extends TestCase
     {
         $loader = new JMSSerializerExtension();
         $container = new ContainerBuilder();
-
-        $container->getCompilerPassConfig()->setOptimizationPasses(array(
-            new ResolveParameterPlaceHoldersPass(),
-            new ResolveDefinitionTemplatesPass(),
-        ));
-        $container->getCompilerPassConfig()->setRemovingPasses(array(new RemoveUnusedDefinitionsPass()));
 
         $container->setParameter('kernel.debug', true);
         $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/serializer');

--- a/Tests/DependencyInjection/JMSSerializerExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSerializerExtensionTest.php
@@ -123,6 +123,16 @@ class JMSSerializerExtensionTest extends TestCase
         $this->assertEquals('foo', (string)$container->getAlias('jms_serializer.serialization_context_factory'));
     }
 
+    public function testLoadWithoutTranslator()
+    {
+        $container = $this->getContainerForConfig(array(array()), function(ContainerBuilder $containerBuilder){
+            $containerBuilder->set('translator', null);
+        });
+
+        $def = $container->getDefinition('jms_serializer.form_error_handler');
+        $this->assertSame(null, $def->getArgument(0));
+    }
+
     public function testConfiguringContextFactories()
     {
         $container = $this->getContainerForConfig(array(array()));

--- a/Tests/DependencyInjection/NamingStrategyTest.php
+++ b/Tests/DependencyInjection/NamingStrategyTest.php
@@ -22,9 +22,6 @@ use JMS\Serializer\Metadata\PropertyMetadata;
 use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 use JMS\SerializerBundle\DependencyInjection\JMSSerializerExtension;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\Compiler\RemoveUnusedDefinitionsPass;
-use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
-use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class NamingStrategyTest extends TestCase
@@ -38,13 +35,6 @@ class NamingStrategyTest extends TestCase
     {
         $loader = new JMSSerializerExtension();
         $container = new ContainerBuilder();
-
-
-        $container->getCompilerPassConfig()->setOptimizationPasses(array(
-            new ResolveParameterPlaceHoldersPass(),
-            new ResolveDefinitionTemplatesPass(),
-        ));
-        $container->getCompilerPassConfig()->setRemovingPasses(array(new RemoveUnusedDefinitionsPass()));
 
         $container->setParameter('kernel.debug', true);
         $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/serializer');

--- a/Tests/DependencyInjection/TwigExtensionPassTest.php
+++ b/Tests/DependencyInjection/TwigExtensionPassTest.php
@@ -21,9 +21,6 @@ namespace JMS\SerializerBundle\Tests\DependencyInjection;
 use JMS\SerializerBundle\DependencyInjection\Compiler\TwigExtensionPass;
 use JMS\SerializerBundle\DependencyInjection\JMSSerializerExtension;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\Compiler\RemoveUnusedDefinitionsPass;
-use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
-use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class TwigExtensionPassTest extends TestCase
@@ -35,12 +32,6 @@ class TwigExtensionPassTest extends TestCase
     {
         $loader = new JMSSerializerExtension();
         $container = new ContainerBuilder();
-
-        $container->getCompilerPassConfig()->setOptimizationPasses(array(
-            new ResolveParameterPlaceHoldersPass(),
-            new ResolveDefinitionTemplatesPass(),
-        ));
-        $container->getCompilerPassConfig()->setRemovingPasses(array(new RemoveUnusedDefinitionsPass()));
 
         $container->setParameter('kernel.debug', true);
         $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/serializer');

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^5.4|^7.0",
-        "jms/serializer": "^1.7",
+        "jms/serializer": "^1.9",
         "phpoption/phpoption": "^1.1.0",
         "symfony/framework-bundle": "~2.3|~3.0|~4.0"
     },


### PR DESCRIPTION
(and improve test cases by using always all default symfony compiler passes)

This is the first step for a better support for symfony 4.0