### PR TITLE
Serializer and stateful dependencies should be unshared

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -45,7 +45,7 @@
         <parameter key="jms_serializer.xml_deserialization_visitor.doctype_whitelist" type="collection"></parameter>
         <parameter key="jms_serializer.xml_serialization_visitor.format_output"></parameter>
         <parameter key="jms_serializer.yaml_serialization_visitor.class">JMS\Serializer\YamlSerializationVisitor</parameter>
-        
+
         <parameter key="jms_serializer.handler_registry.class">JMS\Serializer\Handler\LazyHandlerRegistry</parameter>
 
         <parameter key="jms_serializer.datetime_handler.class">JMS\Serializer\Handler\DateHandler</parameter>
@@ -80,7 +80,7 @@
             <tag name="jms_serializer.event_subscriber" />
             <argument type="service" id="debug.stopwatch" />
         </service>
-        
+
         <!-- Handlers -->
         <service id="jms_serializer.handler_registry" class="%jms_serializer.handler_registry.class%">
             <argument type="service" id="service_container" />
@@ -102,7 +102,7 @@
         <service id="jms_serializer.constraint_violation_handler" class="%jms_serializer.constraint_violation_handler.class%">
             <tag name="jms_serializer.subscribing_handler" />
         </service>
-            
+
         <!-- Metadata Drivers -->
         <service id="jms_serializer.metadata.file_locator" class="%jms_serializer.metadata.file_locator.class%" public="false">
             <argument type="collection" /><!-- Namespace Prefixes mapping to Directories -->
@@ -184,7 +184,7 @@
         <service id="jms_serializer.object_constructor" alias="jms_serializer.unserialize_object_constructor" public="false" />
 
         <!-- Serializer -->
-        <service id="jms_serializer.serializer" class="%jms_serializer.serializer.class%" public="false">
+        <service id="jms_serializer.serializer" class="%jms_serializer.serializer.class%" public="false" shared="false">
             <argument type="service" id="jms_serializer.metadata_factory" />
             <argument type="service" id="jms_serializer.handler_registry" />
             <argument type="service" id="jms_serializer.object_constructor" />
@@ -251,7 +251,7 @@
         </service>
 
         <!-- Visitors -->
-        <service id="jms_serializer.json_serialization_visitor" class="%jms_serializer.json_serialization_visitor.class%">
+        <service id="jms_serializer.json_serialization_visitor" class="%jms_serializer.json_serialization_visitor.class%" shared="false">
             <argument type="service" id="jms_serializer.naming_strategy" />
             <argument type="service" id="jms_serializer.accessor_strategy"/>
             <call method="setOptions">
@@ -259,11 +259,11 @@
             </call>
             <tag name="jms_serializer.serialization_visitor" format="json" />
         </service>
-        <service id="jms_serializer.json_deserialization_visitor" class="%jms_serializer.json_deserialization_visitor.class%">
+        <service id="jms_serializer.json_deserialization_visitor" class="%jms_serializer.json_deserialization_visitor.class%" shared="false">
             <argument type="service" id="jms_serializer.naming_strategy" />
             <tag name="jms_serializer.deserialization_visitor" format="json" />
         </service>
-        <service id="jms_serializer.xml_serialization_visitor" class="%jms_serializer.xml_serialization_visitor.class%">
+        <service id="jms_serializer.xml_serialization_visitor" class="%jms_serializer.xml_serialization_visitor.class%" shared="false">
             <argument type="service" id="jms_serializer.naming_strategy" />
             <argument type="service" id="jms_serializer.accessor_strategy"/>
             <tag name="jms_serializer.serialization_visitor" format="xml" />
@@ -271,14 +271,14 @@
                 <argument>%jms_serializer.xml_serialization_visitor.format_output%</argument>
             </call>
         </service>
-        <service id="jms_serializer.xml_deserialization_visitor" class="%jms_serializer.xml_deserialization_visitor.class%">
+        <service id="jms_serializer.xml_deserialization_visitor" class="%jms_serializer.xml_deserialization_visitor.class%" shared="false">
             <argument type="service" id="jms_serializer.naming_strategy" />
             <call method="setDoctypeWhitelist">
                 <argument>%jms_serializer.xml_deserialization_visitor.doctype_whitelist%</argument>
             </call>
             <tag name="jms_serializer.deserialization_visitor" format="xml" />
         </service>
-        <service id="jms_serializer.yaml_serialization_visitor" class="%jms_serializer.yaml_serialization_visitor.class%">
+        <service id="jms_serializer.yaml_serialization_visitor" class="%jms_serializer.yaml_serialization_visitor.class%" shared="false">
             <argument type="service" id="jms_serializer.naming_strategy" />
             <argument type="service" id="jms_serializer.accessor_strategy"/>
             <tag name="jms_serializer.serialization_visitor" format="yml" />

--- a/Tests/DependencyInjection/JMSSerializerExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSerializerExtensionTest.php
@@ -88,6 +88,23 @@ class JMSSerializerExtensionTest extends TestCase
         $this->assertEquals('jms_serializer.deserialization_context_factory', (string)$serializationCall[1][0]);
     }
 
+    public function testSerializerIsNotShared()
+    {
+        $unsharedServices = array(
+            'jms_serializer',
+            'jms_serializer.json_serialization_visitor',
+            'jms_serializer.xml_serialization_visitor',
+            'jms_serializer.yaml_serialization_visitor',
+            'jms_serializer.json_deserialization_visitor',
+            'jms_serializer.xml_deserialization_visitor',
+        );
+
+        $container = $this->getContainerForConfig(array(array()));
+        foreach ($unsharedServices as $serviceId) {
+            $this->assertFalse($container->getDefinition($serviceId)->isShared(), $serviceId . ' is not shared');
+        }
+    }
+
     public function testSerializerContextFactoriesWithId()
     {
         $config = array(


### PR DESCRIPTION
An invocation of `Serializer::serialize()` leads to "Can't pop from an empty datastructure" in `SplStack` if the serializer invocation leads to another serializer invocation on the same service down the road. In my case that happened when the serializer used doctrine to load an entity which logged a message on dev but there was logging functionality that uses the serializer. 

This is the reproduction case:
```php
class Foo
{
    /** @Serializer\Exclude() */
    public $serializer;
    /** @Serializer\Accessor(getter="get") */
    private $property;
    public function get() { return $this->serializer->serialize('foo', 'json'); }
}

$serializer = $container->get('jms_serializer');
$obj = new Foo();
$obj->serializer = $container->get('jms_serializer');

$serializer->serialize($obj, 'json');
```
 
To fix this, `jms_serializer` and its stateful dependencies may not be shared. This PR marks the following services as not shared:

- jms_serializer
- jms_serializer.json_serialization_visitor
- jms_serializer.xml_serialization_visitor
- jms_serializer.yaml_serialization_visitor
- jms_serializer.json_deserialization_visitor
- jms_serializer.xml_deserialization_visitor