### PR TITLE
make it possible to decorate services

### DIFF
--- a/DependencyInjection/Compiler/CustomHandlersPass.php
+++ b/DependencyInjection/Compiler/CustomHandlersPass.php
@@ -67,7 +67,7 @@ class CustomHandlersPass implements CompilerPassInterface
             }
         }
 
-        $container->getDefinition('jms_serializer.handler_registry')
+        $container->findDefinition('jms_serializer.handler_registry')
             ->addArgument($handlers);
     }
 }

--- a/DependencyInjection/Compiler/DoctrinePass.php
+++ b/DependencyInjection/Compiler/DoctrinePass.php
@@ -48,7 +48,7 @@ class DoctrinePass implements CompilerPassInterface
             foreach ($serviceTemplates as $serviceName => $service) {
                 $id = sprintf($service['template'], $registry);
                 $container
-                    ->getDefinition($id)
+                    ->findDefinition($id)
                     ->replaceArgument($service['position'], new Reference($previousId[$serviceName]));
                 $previousId[$serviceName] = $id;
                 $container->setAlias($serviceName, new Alias($previousId[$serviceName], true));

--- a/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
+++ b/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
@@ -71,7 +71,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
                 $events = call_user_func_array('array_merge', $events);
             }
 
-            $container->getDefinition('jms_serializer.event_dispatcher')
+            $container->findDefinition('jms_serializer.event_dispatcher')
                 ->addMethodCall('setListeners', array($listeners));
         }
     }

--- a/DependencyInjection/Compiler/TwigExtensionPass.php
+++ b/DependencyInjection/Compiler/TwigExtensionPass.php
@@ -18,7 +18,7 @@ class TwigExtensionPass implements CompilerPassInterface
             return;
         }
 
-        $def = $container->getDefinition('jms_serializer.twig_extension.serializer');
+        $def = $container->findDefinition('jms_serializer.twig_extension.serializer');
         $def->setClass('%jms_serializer.twig_runtime_extension.class%');
         $def->setArguments(array());
     }


### PR DESCRIPTION
If another part of the application decorates a built-in service, the
compiler passes will fail if they run after service decorators have
been resolved (in this case, the original service id is an alias
pointing to the decorating service).