### PR TITLE
drop getDefinition() in favor of findDefinition()

### DIFF
--- a/DependencyInjection/Compiler/CustomHandlersPass.php
+++ b/DependencyInjection/Compiler/CustomHandlersPass.php
@@ -76,7 +76,7 @@ class CustomHandlersPass implements CompilerPassInterface
 
         if (class_exists(ServiceLocatorTagPass::class)) {
             $serviceLocator = ServiceLocatorTagPass::register($container, $handlerServices);
-            $container->getDefinition('jms_serializer.handler_registry')->replaceArgument(0, $serviceLocator);
+            $container->findDefinition('jms_serializer.handler_registry')->replaceArgument(0, $serviceLocator);
         }
     }
 }


### PR DESCRIPTION
There was a conflict between #618 and #620 which should be resolved by this change.