### PR TITLE
make serializer/deserializer visitor services public

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -256,7 +256,7 @@
         </service>
 
         <!-- Visitors -->
-        <service id="jms_serializer.json_serialization_visitor" class="%jms_serializer.json_serialization_visitor.class%">
+        <service id="jms_serializer.json_serialization_visitor" class="%jms_serializer.json_serialization_visitor.class%" public="true">
             <argument type="service" id="jms_serializer.naming_strategy" />
             <argument type="service" id="jms_serializer.accessor_strategy"/>
             <call method="setOptions">
@@ -264,11 +264,11 @@
             </call>
             <tag name="jms_serializer.serialization_visitor" format="json" />
         </service>
-        <service id="jms_serializer.json_deserialization_visitor" class="%jms_serializer.json_deserialization_visitor.class%">
+        <service id="jms_serializer.json_deserialization_visitor" class="%jms_serializer.json_deserialization_visitor.class%" public="true">
             <argument type="service" id="jms_serializer.naming_strategy" />
             <tag name="jms_serializer.deserialization_visitor" format="json" />
         </service>
-        <service id="jms_serializer.xml_serialization_visitor" class="%jms_serializer.xml_serialization_visitor.class%">
+        <service id="jms_serializer.xml_serialization_visitor" class="%jms_serializer.xml_serialization_visitor.class%" public="true">
             <argument type="service" id="jms_serializer.naming_strategy" />
             <argument type="service" id="jms_serializer.accessor_strategy"/>
             <tag name="jms_serializer.serialization_visitor" format="xml" />
@@ -276,14 +276,14 @@
                 <argument>%jms_serializer.xml_serialization_visitor.format_output%</argument>
             </call>
         </service>
-        <service id="jms_serializer.xml_deserialization_visitor" class="%jms_serializer.xml_deserialization_visitor.class%">
+        <service id="jms_serializer.xml_deserialization_visitor" class="%jms_serializer.xml_deserialization_visitor.class%" public="true">
             <argument type="service" id="jms_serializer.naming_strategy" />
             <call method="setDoctypeWhitelist">
                 <argument>%jms_serializer.xml_deserialization_visitor.doctype_whitelist%</argument>
             </call>
             <tag name="jms_serializer.deserialization_visitor" format="xml" />
         </service>
-        <service id="jms_serializer.yaml_serialization_visitor" class="%jms_serializer.yaml_serialization_visitor.class%">
+        <service id="jms_serializer.yaml_serialization_visitor" class="%jms_serializer.yaml_serialization_visitor.class%" public="true">
             <argument type="service" id="jms_serializer.naming_strategy" />
             <argument type="service" id="jms_serializer.accessor_strategy"/>
             <tag name="jms_serializer.serialization_visitor" format="yml" />


### PR DESCRIPTION
Since Symfony 3.2, getting private service from the container has been deprecated.
This PR solves issue #632.