### PR TITLE
Proposal: Add priorities feature to handlers

### DIFF
--- a/DependencyInjection/Compiler/CustomHandlersPass.php
+++ b/DependencyInjection/Compiler/CustomHandlersPass.php
@@ -15,8 +15,11 @@ class CustomHandlersPass implements CompilerPassInterface
     {
         $handlers = array();
         $handlerServices = array();
-        foreach ($container->findTaggedServiceIds('jms_serializer.handler') as $id => $tags) {
-            foreach ($tags as $attrs) {
+        foreach ($this->findAndSortTaggedServices('jms_serializer.handler', $container) as $reference) {
+            $id = (string)$reference;
+            $definition = $container->getDefinition($id);
+            foreach ($definition->getTags() as $serviceTags) {
+                $attrs = $serviceTags[0];
                 if (!isset($attrs['type'], $attrs['format'])) {
                     throw new \RuntimeException(sprintf('Each tag named "jms_serializer.handler" of service "%s" must have at least two attributes: "type" and "format".', $id));
                 }
@@ -32,18 +35,20 @@ class CustomHandlersPass implements CompilerPassInterface
 
                 foreach ($directions as $direction) {
                     $method = isset($attrs['method']) ? $attrs['method'] : HandlerRegistry::getDefaultMethod($direction, $attrs['type'], $attrs['format']);
-                    if (class_exists(ServiceLocatorTagPass::class) || $container->getDefinition($id)->isPublic()) {
-                        $handlerServices[$id] = new Reference($id);
+                    if (class_exists(ServiceLocatorTagPass::class) || $definition->isPublic()) {
+                        $handlerServices[$id] = $reference;
                         $handlers[$direction][$attrs['type']][$attrs['format']] = array($id, $method);
                     } else {
-                        $handlers[$direction][$attrs['type']][$attrs['format']] = array(new Reference($id), $method);
+                        $handlers[$direction][$attrs['type']][$attrs['format']] = array($reference, $method);
                     }
                 }
             }
         }
 
-        foreach ($container->findTaggedServiceIds('jms_serializer.subscribing_handler') as $id => $tags) {
-            $class = $container->getDefinition($id)->getClass();
+        foreach ($this->findAndSortTaggedServices('jms_serializer.subscribing_handler', $container) as $reference) {
+            $id = (string)$reference;
+            $definition = $container->getDefinition($id);
+            $class = $definition->getClass();
             $ref = new \ReflectionClass($class);
             if (!$ref->implementsInterface('JMS\Serializer\Handler\SubscribingHandlerInterface')) {
                 throw new \RuntimeException(sprintf('The service "%s" must implement the SubscribingHandlerInterface.', $id));
@@ -61,22 +66,63 @@ class CustomHandlersPass implements CompilerPassInterface
 
                 foreach ($directions as $direction) {
                     $method = isset($methodData['method']) ? $methodData['method'] : HandlerRegistry::getDefaultMethod($direction, $methodData['type'], $methodData['format']);
-                    if (class_exists(ServiceLocatorTagPass::class) || $container->getDefinition($id)->isPublic()) {
-                        $handlerServices[$id] = new Reference($id);
+                    if (class_exists(ServiceLocatorTagPass::class) || $definition->isPublic()) {
+                        $handlerServices[$id] = $reference;
                         $handlers[$direction][$methodData['type']][$methodData['format']] = array($id, $method);
                     } else {
-                        $handlers[$direction][$methodData['type']][$methodData['format']] = array(new Reference($id), $method);
+                        $handlers[$direction][$methodData['type']][$methodData['format']] = array($reference, $method);
                     }
                 }
             }
         }
 
-        $container->findDefinition('jms_serializer.handler_registry')
-            ->addArgument($handlers);
+        $container->findDefinition('jms_serializer.handler_registry')->addArgument($handlers);
 
         if (class_exists(ServiceLocatorTagPass::class)) {
             $serviceLocator = ServiceLocatorTagPass::register($container, $handlerServices);
             $container->findDefinition('jms_serializer.handler_registry')->replaceArgument(0, $serviceLocator);
         }
+    }
+
+    /**
+     * Finds all services with the given tag name and order them by their priority.
+     *
+     * The order of additions must be respected for services having the same priority,
+     * and knowing that the \SplPriorityQueue class does not respect the FIFO method,
+     * we should not use that class.
+     *
+     * Original author is Iltar van der Berg <kjarli@gmail.com>
+     *
+     * @see https://bugs.php.net/bug.php?id=53710
+     * @see https://bugs.php.net/bug.php?id=60926
+     *
+     * @param string           $tagName
+     * @param ContainerBuilder $container
+     *
+     * @return Reference[]
+     */
+    private function findAndSortTaggedServices($tagName, ContainerBuilder $container)
+    {
+        $services = array();
+
+        foreach ($container->findTaggedServiceIds($tagName, true) as $serviceId => $attributes) {
+            $definition = $container->getDefinition($serviceId);
+
+            if (!isset($attributes[0]['priority'])) {
+                $class = $definition->getClass();
+                $priority = strpos($class, 'JMS\Serializer') === 0 ? 100 : 0;
+            } else {
+                $priority = $attributes[0]['priority'];
+            }
+
+            $services[$priority][] = new Reference($serviceId);
+        }
+
+        if ($services) {
+            krsort($services);
+            $services = call_user_func_array('array_merge', $services);
+        }
+
+        return $services;
     }
 }

--- a/Tests/DependencyInjection/CustomHandlerPassTest.php
+++ b/Tests/DependencyInjection/CustomHandlerPassTest.php
@@ -158,6 +158,72 @@ class CustomHandlerPassTest extends TestCase
         $pass->process($container);
     }
 
+    public function testHandlerMustPrioritizeUserDefined()
+    {
+        $container = $this->getContainer();
+
+        $def = new Definition('JMS\Serializer\Foo');
+        $def->addTag('jms_serializer.handler', [
+            'type' => 'DateTime',
+            'format' => 'json',
+        ]);
+        $container->setDefinition('my_service', $def);
+
+        $userDef = new Definition('Bar');
+        $userDef->addTag('jms_serializer.handler', [
+            'type' => 'DateTime',
+            'format' => 'json',
+        ]);
+        $container->setDefinition('my_custom_service', $userDef);
+
+        $pass = new CustomHandlersPass();
+        $pass->process($container);
+
+        $args = $container->getDefinition('jms_serializer.handler_registry')->getArguments();
+
+        $this->assertSame([
+            2 => ['DateTime' => ['json' => ['my_custom_service', 'deserializeDateTimeFromjson']]],
+            1 => ['DateTime' => ['json' => ['my_custom_service', 'serializeDateTimeTojson']]]
+        ], $args[1]);
+    }
+
+    public function testHandlerMustRespectPriorities()
+    {
+        $container = $this->getContainer();
+
+        $def = new Definition('JMS\Serializer\Foo');
+        $def->addTag('jms_serializer.handler', [
+            'type' => 'DateTime',
+            'format' => 'json',
+        ]);
+        $container->setDefinition('my_service', $def);
+
+        $userDef = new Definition('Bar');
+        $userDef->addTag('jms_serializer.handler', [
+            'type' => 'DateTime',
+            'format' => 'json',
+        ]);
+        $container->setDefinition('my_custom_service', $userDef);
+
+        $userExplicitDef = new Definition('Baz');
+        $userExplicitDef->addTag('jms_serializer.handler', [
+            'type' => 'DateTime',
+            'format' => 'json',
+            'priority' => -100
+        ]);
+        $container->setDefinition('my_custom_explicit_service', $userExplicitDef);
+
+        $pass = new CustomHandlersPass();
+        $pass->process($container);
+
+        $args = $container->getDefinition('jms_serializer.handler_registry')->getArguments();
+
+        $this->assertSame([
+          2 => ['DateTime' => ['json' => ['my_custom_explicit_service', 'deserializeDateTimeFromjson']]],
+          1 => ['DateTime' => ['json' => ['my_custom_explicit_service', 'serializeDateTimeTojson']]]
+        ], $args[1]);
+    }
+
     public function testSubscribingHandler()
     {
         $container = $this->getContainer();
@@ -210,4 +276,53 @@ class CustomHandlerPassTest extends TestCase
         $pass = new CustomHandlersPass();
         $pass->process($container);
     }
+
+    public function testSubscribingHandlerMustPrioritizeUserDefined()
+    {
+        $container = $this->getContainer();
+
+        $def = new Definition('JMS\SerializerBundle\Tests\DependencyInjection\Fixture\SubscribingHandler');
+        $def->addTag('jms_serializer.subscribing_handler');
+        $container->setDefinition('my_service', $def);
+
+        $userDef = new Definition('UserDefined\Foo\UserDefinedSubscribingHandler');
+        $userDef->addTag('jms_serializer.subscribing_handler');
+        $container->setDefinition('my_custom_service', $userDef);
+
+        $pass = new CustomHandlersPass();
+        $pass->process($container);
+
+        $args = $container->getDefinition('jms_serializer.handler_registry')->getArguments();
+
+        $this->assertSame([
+            1 => ['DateTime' => ['json' => ['my_custom_service', 'onDateTime']]]
+        ], $args[1]);
+    }
+
+    public function testSubscribingHandlerMustRespectPriorities()
+    {
+        $container = $this->getContainer();
+
+        $def = new Definition('JMS\SerializerBundle\Tests\DependencyInjection\Fixture\SubscribingHandler');
+        $def->addTag('jms_serializer.subscribing_handler');
+        $container->setDefinition('my_service', $def);
+
+        $userDef = new Definition('UserDefined\Foo\UserDefinedSubscribingHandler');
+        $userDef->addTag('jms_serializer.subscribing_handler');
+        $container->setDefinition('my_custom_service', $userDef);
+
+        $userExplicitDef = new Definition('UserDefined\Foo\UserDefinedSubscribingHandler');
+        $userExplicitDef->addTag('jms_serializer.subscribing_handler', ['priority' => -100]);
+        $container->setDefinition('my_custom_explicit_service', $userExplicitDef);
+
+        $pass = new CustomHandlersPass();
+        $pass->process($container);
+
+        $args = $container->getDefinition('jms_serializer.handler_registry')->getArguments();
+
+        $this->assertSame([
+            1 => ['DateTime' => ['json' => ['my_custom_explicit_service', 'onDateTime']]]
+        ], $args[1]);
+    }
+
 }

--- a/Tests/DependencyInjection/Fixture/UserDefined/UserDefinedSubscribingHandler.php
+++ b/Tests/DependencyInjection/Fixture/UserDefined/UserDefinedSubscribingHandler.php
@@ -1,0 +1,21 @@
+<?php
+namespace UserDefined\Foo;
+
+use JMS\Serializer\GraphNavigator;
+use JMS\Serializer\Handler\SubscribingHandlerInterface;
+
+class UserDefinedSubscribingHandler implements SubscribingHandlerInterface
+{
+    public static function getSubscribingMethods()
+    {
+        return array(
+            array(
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'format' => 'json',
+                'type' => 'DateTime',
+                'method' => 'onDateTime',
+            ),
+        );
+    }
+}
+

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,10 @@
         ]
     },
     "autoload-dev": {
-        "psr-4": { "JMS\\SerializerBundle\\Tests\\": "Tests" }
+        "psr-4": {
+            "JMS\\SerializerBundle\\Tests\\": "Tests",
+            "UserDefined\\Foo\\": "Tests/DependencyInjection/Fixture/UserDefined"
+        }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
As a response to #642, #641 and #466 I prepared a proposal of change/feature in this regard, which should improve DX and let developers avoid confusion or similar problems in future.

What these changes introduce:

1. Possibility to give `jms_serializer.handler` and `jms_serializer.subscribing_handler` tags a priority attribute
2. `CustomHandlersPass` is loading handlers respecting order based on priorities
3. Standard handlers have a default priority set to `100` (ones from `JMS\Serializer` namespace)
4. Custom defined handlers (outside of namespace above) have a default priority set to `0` (will override standard ones by default)