### PR TITLE
Change when the DoctrinePass is run

### DIFF
--- a/JMSSerializerBundle.php
+++ b/JMSSerializerBundle.php
@@ -47,9 +47,9 @@ class JMSSerializerBundle extends Bundle
 
         $builder->addCompilerPass(new FormErrorHandlerTranslationDomainPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION);
         $builder->addCompilerPass(new TwigExtensionPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION);
+        $builder->addCompilerPass(new DoctrinePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION);
         $builder->addCompilerPass(new RegisterEventListenersAndSubscribersPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $builder->addCompilerPass(new CustomHandlersPass(), PassConfig::TYPE_BEFORE_REMOVING);
-        $builder->addCompilerPass(new DoctrinePass(), PassConfig::TYPE_BEFORE_REMOVING);
     }
 
     private function getServiceMapPass($tagName, $keyAttributeName, $callable)


### PR DESCRIPTION
https://symfony.com/doc/current/components/dependency_injection/compilation.html#controlling-the-pass-ordering

> The default compiler passes are grouped into optimization passes and removal passes. The optimization passes run first and include tasks such as resolving references within the definitions. The removal passes perform tasks such as removing private aliases and unused services.

"Before removing" is too late to run the DoctrinePass, because `jms_serializer.serializer` would continue using `jms_serializer.unserialize_object_constructor` (the alias was already resolved).