### PR TITLE
Fix serialization handler registration by priority

### DIFF
--- a/DependencyInjection/Compiler/CustomHandlersPass.php
+++ b/DependencyInjection/Compiler/CustomHandlersPass.php
@@ -15,33 +15,17 @@ class CustomHandlersPass implements CompilerPassInterface
     {
         $handlers = array();
         $handlerServices = array();
-        foreach ($this->findAndSortTaggedServices('jms_serializer.handler', $container) as $reference) {
+        foreach ($this->findAndSortTaggedHandlers($container) as $attrs) {
+            $direction = $attrs['direction'];
+            $reference = $attrs['reference'];
             $id = (string)$reference;
             $definition = $container->getDefinition($id);
-            foreach ($definition->getTags() as $serviceTags) {
-                $attrs = $serviceTags[0];
-                if (!isset($attrs['type'], $attrs['format'])) {
-                    throw new \RuntimeException(sprintf('Each tag named "jms_serializer.handler" of service "%s" must have at least two attributes: "type" and "format".', $id));
-                }
-
-                $directions = array(GraphNavigator::DIRECTION_DESERIALIZATION, GraphNavigator::DIRECTION_SERIALIZATION);
-                if (isset($attrs['direction'])) {
-                    if (!defined($directionConstant = 'JMS\Serializer\GraphNavigator::DIRECTION_' . strtoupper($attrs['direction']))) {
-                        throw new \RuntimeException(sprintf('The direction "%s" of tag "jms_serializer.handler" of service "%s" does not exist.', $attrs['direction'], $id));
-                    }
-
-                    $directions = array(constant($directionConstant));
-                }
-
-                foreach ($directions as $direction) {
-                    $method = isset($attrs['method']) ? $attrs['method'] : HandlerRegistry::getDefaultMethod($direction, $attrs['type'], $attrs['format']);
-                    if (class_exists(ServiceLocatorTagPass::class) || $definition->isPublic()) {
-                        $handlerServices[$id] = $reference;
-                        $handlers[$direction][$attrs['type']][$attrs['format']] = array($id, $method);
-                    } else {
-                        $handlers[$direction][$attrs['type']][$attrs['format']] = array($reference, $method);
-                    }
-                }
+            $method = isset($attrs['method']) ? $attrs['method'] : HandlerRegistry::getDefaultMethod($direction, $attrs['type'], $attrs['format']);
+            if (class_exists(ServiceLocatorTagPass::class) || $definition->isPublic()) {
+                $handlerServices[$id] = $reference;
+                $handlers[$direction][$attrs['type']][$attrs['format']] = array($id, $method);
+            } else {
+                $handlers[$direction][$attrs['type']][$attrs['format']] = array($reference, $method);
             }
         }
 
@@ -82,6 +66,55 @@ class CustomHandlersPass implements CompilerPassInterface
             $serviceLocator = ServiceLocatorTagPass::register($container, $handlerServices);
             $container->findDefinition('jms_serializer.handler_registry')->replaceArgument(0, $serviceLocator);
         }
+    }
+
+    /**
+     * Finds all handler services with the given tag name and order them by their priority.
+     *
+     * @param ContainerBuilder $container
+     *
+     * @return Reference[]
+     */
+    private function findAndSortTaggedHandlers(ContainerBuilder $container)
+    {
+        $services = array();
+
+        foreach ($container->findTaggedServiceIds('jms_serializer.handler', true) as $serviceId => $attributeList) {
+            foreach ($attributeList as $attributes) {
+                if (!isset($attributes['type'], $attributes['format'])) {
+                    throw new \RuntimeException(sprintf('Each tag named "jms_serializer.handler" of service "%s" must have at least two attributes: "type" and "format".', $serviceId));
+                }
+
+                $directions = array(GraphNavigator::DIRECTION_DESERIALIZATION, GraphNavigator::DIRECTION_SERIALIZATION);
+                if (isset($attributes['direction'])) {
+                    if (!defined($directionConstant = 'JMS\Serializer\GraphNavigator::DIRECTION_' . strtoupper($attributes['direction']))) {
+                        throw new \RuntimeException(sprintf('The direction "%s" of tag "jms_serializer.handler" of service "%s" does not exist.', $attributes['direction'], $serviceId));
+                    }
+
+                    $directions = array(constant($directionConstant));
+                }
+
+                $priority = isset($attributes[0]['priority']) ? intval($attributes[0]['priority']) : 0;
+                foreach ($directions as $direction) {
+                    $services[$direction . $attributes['type'] . $attributes['format']][$priority][] = array_merge(
+                        $attributes,
+                        [
+                            'direction' => $direction,
+                            'reference' => new Reference($serviceId)
+                        ]
+                    );
+                }
+            }
+        }
+
+        if ($services) {
+            foreach ($services as $combination => $handlers) {
+                krsort($handlers);
+                $services[$combination] = array_reverse(call_user_func_array('array_merge', $handlers))[0];
+            }
+        }
+
+        return $services;
     }
 
     /**

--- a/Tests/DependencyInjection/CustomHandlerPassTest.php
+++ b/Tests/DependencyInjection/CustomHandlerPassTest.php
@@ -224,6 +224,54 @@ class CustomHandlerPassTest extends TestCase
         ], $args[1]);
     }
 
+    public function testHandlerCanBeRegisteredForMultipleTypesOrDirections()
+    {
+        $container = $this->getContainer();
+
+        $def = new Definition('JMS\Serializer\Foo');
+        $def->addTag('jms_serializer.handler', [
+            'type' => 'Custom',
+            'direction' => 'serialization',
+            'format' => 'json',
+            'method' => 'serialize',
+        ]);
+        $def->addTag('jms_serializer.handler', [
+            'type' => 'Custom',
+            'direction' => 'deserialization',
+            'format' => 'json',
+            'method' => 'deserialize',
+        ]);
+        $def->addTag('jms_serializer.handler', [
+            'type' => 'Custom<?>',
+            'direction' => 'serialization',
+            'format' => 'json',
+            'method' => 'serialize',
+        ]);
+        $def->addTag('jms_serializer.handler', [
+            'type' => 'Custom<?>',
+            'direction' => 'deserialization',
+            'format' => 'json',
+            'method' => 'deserialize',
+        ]);
+        $container->setDefinition('my_service', $def);
+
+        $pass = new CustomHandlersPass();
+        $pass->process($container);
+
+        $args = $container->getDefinition('jms_serializer.handler_registry')->getArguments();
+
+        $this->assertSame([
+            1 => [
+                'Custom' => ['json' => ['my_service', 'serialize']],
+                'Custom<?>' => ['json' => ['my_service', 'serialize']],
+            ],
+            2 => [
+                'Custom' => ['json' => ['my_service', 'deserialize']],
+                'Custom<?>' => ['json' => ['my_service', 'deserialize']],
+            ]
+        ], $args[1]);
+    }
+
     public function testSubscribingHandler()
     {
         $container = $this->getContainer();


### PR DESCRIPTION
This fixes #656 by examining the priorities for each direction+type+format combination and not globally.

This now allows to register the same handler for multiple types and/or formats as it was possible in pre 2.4 versions.