### PR TITLE
Add autoconfigure for handlers

### DIFF
--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -4,6 +4,7 @@ namespace JMS\SerializerBundle\DependencyInjection;
 
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\Exception\RuntimeException;
+use JMS\Serializer\Handler\SubscribingHandlerInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -17,11 +18,13 @@ class JMSSerializerExtension extends ConfigurableExtension
 {
     public function loadInternal(array $config, ContainerBuilder $container)
     {
-        if (method_exists($container, 'registerForAutoconfiguration')) {
-            $container
-                ->registerForAutoconfiguration(EventSubscriberInterface::class)
-                ->addTag('jms_serializer.event_subscriber');
-        }
+        $container
+            ->registerForAutoconfiguration(EventSubscriberInterface::class)
+            ->addTag('jms_serializer.event_subscriber');
+
+        $container
+            ->registerForAutoconfiguration(SubscribingHandlerInterface::class)
+            ->addTag('jms_serializer.subscribing_handler');
 
         $loader = new XmlFileLoader($container, new FileLocator(array(
             __DIR__ . '/../Resources/config/')));

--- a/Tests/DependencyInjection/JMSSerializerExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSerializerExtensionTest.php
@@ -3,6 +3,7 @@
 namespace JMS\SerializerBundle\Tests\DependencyInjection;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use JMS\Serializer\Handler\SubscribingHandlerInterface;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\SerializerBundle\JMSSerializerBundle;
@@ -499,18 +500,21 @@ class JMSSerializerExtensionTest extends TestCase
     {
         $container = $this->getContainerForConfig(array());
 
-        if (!method_exists($container, 'registerForAutoconfiguration')) {
-            $this->markTestSkipped(
-                'registerForAutoconfiguration method is not available in the container'
-            );
-        }
-
         $autoconfigureInstance = $container->getAutoconfiguredInstanceof();
 
         $this->assertTrue(array_key_exists(EventSubscriberInterface::class, $autoconfigureInstance));
         $this->assertTrue($autoconfigureInstance[EventSubscriberInterface::class]->hasTag('jms_serializer.event_subscriber'));
     }
 
+    public function testAutoconfigureHandlers()
+    {
+        $container = $this->getContainerForConfig(array());
+
+        $autoconfigureInstance = $container->getAutoconfiguredInstanceof();
+
+        $this->assertTrue(array_key_exists(SubscribingHandlerInterface::class, $autoconfigureInstance));
+        $this->assertTrue($autoconfigureInstance[SubscribingHandlerInterface::class]->hasTag('jms_serializer.subscribing_handler'));
+    }
 
     private function getContainerForConfigLoad(array $configs)
     {


### PR DESCRIPTION
Such like events we can auto configure handlers. 
Also remove checks for `registerForAutoconfiguration` as `symfony/dependency-injection` required version is `^3.3`.