### PR TITLE
Add autoconfigure for handlers

### DIFF
--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -4,6 +4,7 @@ namespace JMS\SerializerBundle\DependencyInjection;
 
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\Exception\RuntimeException;
+use JMS\Serializer\Handler\SubscribingHandlerInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -21,6 +22,10 @@ class JMSSerializerExtension extends ConfigurableExtension
             $container
                 ->registerForAutoconfiguration(EventSubscriberInterface::class)
                 ->addTag('jms_serializer.event_subscriber');
+
+            $container
+                ->registerForAutoconfiguration(SubscribingHandlerInterface::class)
+                ->addTag('jms_serializer.subscribing_handler');
         }
 
         $loader = new XmlFileLoader($container, new FileLocator(array(

--- a/Tests/DependencyInjection/JMSSerializerExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSerializerExtensionTest.php
@@ -3,6 +3,7 @@
 namespace JMS\SerializerBundle\Tests\DependencyInjection;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use JMS\Serializer\Handler\SubscribingHandlerInterface;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\SerializerBundle\JMSSerializerBundle;
@@ -529,6 +530,22 @@ class JMSSerializerExtensionTest extends TestCase
 
         $this->assertTrue(array_key_exists(EventSubscriberInterface::class, $autoconfigureInstance));
         $this->assertTrue($autoconfigureInstance[EventSubscriberInterface::class]->hasTag('jms_serializer.event_subscriber'));
+    }
+
+    public function testAutoconfigureHandlers()
+    {
+        $container = $this->getContainerForConfig(array());
+
+        if (!method_exists($container, 'registerForAutoconfiguration')) {
+            $this->markTestSkipped(
+                'registerForAutoconfiguration method is not available in the container'
+            );
+        }
+
+        $autoconfigureInstance = $container->getAutoconfiguredInstanceof();
+
+        $this->assertTrue(array_key_exists(SubscribingHandlerInterface::class, $autoconfigureInstance));
+        $this->assertTrue($autoconfigureInstance[SubscribingHandlerInterface::class]->hasTag('jms_serializer.subscribing_handler'));
     }
 
     private function getContainerForConfig(array $configs, callable $configurator = null)


### PR DESCRIPTION
Same as #670 but for 2.x 

So basically only with the `registerForAutoconfiguration` checks.