### PR TITLE
EventDispatcher - use case sensitive event names;

### DIFF
--- a/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
+++ b/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
@@ -22,7 +22,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
                 }
 
                 $class = isset($attributes['class'])
-                    ? strtolower($container->getParameterBag()->resolveValue($attributes['class']))
+                    ? $container->getParameterBag()->resolveValue($attributes['class'])
                     : null;
 
                 $format = isset($attributes['format']) ? $attributes['format'] : null;
@@ -52,7 +52,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
                     throw new \RuntimeException(sprintf('The service "%s" (class: %s) must return an event for each subscribed event.', $id, $subscriberClass));
                 }
 
-                $class = isset($eventData['class']) ? strtolower($eventData['class']) : null;
+                $class = isset($eventData['class']) ? $eventData['class'] : null;
                 $format = isset($eventData['format']) ? $eventData['format'] : null;
                 $method = isset($eventData['method']) ? $eventData['method'] : EventDispatcher::getDefaultMethodName($eventData['event']);
                 $priority = isset($eventData['priority']) ? (integer)$eventData['priority'] : 0;

--- a/Tests/DependencyInjection/EventSubscribersAndListenersPassTest.php
+++ b/Tests/DependencyInjection/EventSubscribersAndListenersPassTest.php
@@ -121,7 +121,7 @@ class EventSubscribersAndListenersPassTest extends TestCase
                     'serializer.pre_serialize' => [
                         [
                             ['my_listener', 'onserializerpreserialize'],
-                            'bar',
+                            'Bar',
                             null
                         ]
                     ]], $call[1][0]);
@@ -161,7 +161,7 @@ class EventSubscribersAndListenersPassTest extends TestCase
                     'serializer.pre_serialize' => [
                         [
                             ['my_listener', 'onserializerpreserialize'],
-                            'bar',
+                            'Bar',
                             null
                         ]
                     ]], $call[1][0]);
@@ -196,7 +196,7 @@ class EventSubscribersAndListenersPassTest extends TestCase
                     'serializer.pre_serialize' => [
                         [
                             ['my_listener', 'onserializerpreserialize'],
-                            'bar',
+                            'Bar',
                             'json',
                             null
                         ]


### PR DESCRIPTION
You forgot to adapt CompilerPass for changes in commit below.

https://github.com/schmittjoh/serializer/commit/d0cf4cbca029bf55eb3d4061b3affbe3c2022f2b#diff-f5a58b28905e2b53063b7633beb9e605

