### PR TITLE
Rename Twig_RuntimeLoaderInterface

### DIFF
--- a/DependencyInjection/Compiler/TwigExtensionPass.php
+++ b/DependencyInjection/Compiler/TwigExtensionPass.php
@@ -13,7 +13,7 @@ class TwigExtensionPass implements CompilerPassInterface
     {
         if (!$container->hasDefinition('twig.runtime_loader')
             || !class_exists(SerializerRuntimeExtension::class)
-            || !interface_exists('Twig_RuntimeLoaderInterface')
+            || !interface_exists('Twig\RuntimeLoader\RuntimeLoaderInterface')
             || !class_exists(SerializerRuntimeHelper::class)
         ) {
             $container->removeDefinition('jms_serializer.twig_extension.serializer_runtime_helper');


### PR DESCRIPTION
`Twig_RuntimeLoaderInterface`'s name has changed in twig and is deprecated since v2.7:

https://github.com/twigphp/Twig/blob/1a05a525bbf320c50a105723c481df8156947eb8/lib/Twig/RuntimeLoaderInterface.php

This raises deprecation notices