### PR TITLE
Add service aliases in order to enable autowiring for "configured_serialization_context_factory" and "configured_deserialization_context_factory"

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -20,7 +20,7 @@
             <tag name="jms_serializer.event_subscriber" />
             <argument type="service" id="debug.stopwatch" />
         </service>
-        
+
         <!-- Handlers -->
         <service id="jms_serializer.handler_registry" class="JMS\Serializer\Handler\LazyHandlerRegistry">
             <argument type="service" id="service_container" />
@@ -232,5 +232,8 @@
         <service id="jms_serializer.configured_deserialization_context_factory"
                  class="JMS\SerializerBundle\ContextFactory\ConfiguredContextFactory"
                  public="false" />
+
+        <service id="JMS\Serializer\ContextFactory\SerializationContextFactoryInterface" alias="jms_serializer.configured_serialization_context_factory" public="false"/>
+        <service id="JMS\Serializer\ContextFactory\DeserializationContextFactoryInterface" alias="jms_serializer.configured_deserialization_context_factory" public="false"/>
     </services>
 </container>

--- a/Tests/DependencyInjection/JMSSerializerExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSerializerExtensionTest.php
@@ -209,6 +209,8 @@ class JMSSerializerExtensionTest extends TestCase
             $container->getDefinition('jms_serializer.doctrine_proxy_subscriber')->setPublic(true);
             $container->getAlias('JMS\Serializer\SerializerInterface')->setPublic(true);
             $container->getAlias('JMS\Serializer\ArrayTransformerInterface')->setPublic(true);
+            $container->getAlias('JMS\Serializer\ContextFactory\SerializationContextFactoryInterface')->setPublic(true);
+            $container->getAlias('JMS\Serializer\ContextFactory\DeserializationContextFactoryInterface')->setPublic(true);
         });
 
         $simpleObject = new SimpleObject('foo', 'bar');
@@ -217,6 +219,8 @@ class JMSSerializerExtensionTest extends TestCase
 
         $this->assertTrue($container->has('JMS\Serializer\SerializerInterface'), 'Alias should be defined to allow autowiring');
         $this->assertTrue($container->has('JMS\Serializer\ArrayTransformerInterface'), 'Alias should be defined to allow autowiring');
+        $this->assertTrue($container->has('JMS\Serializer\ContextFactory\SerializationContextFactoryInterface'), 'Alias should be defined to allow autowiring');
+        $this->assertTrue($container->has('JMS\Serializer\ContextFactory\DeserializationContextFactoryInterface'), 'Alias should be defined to allow autowiring');
 
         $this->assertFalse($container->getDefinition('jms_serializer.array_collection_handler')->getArgument(0));
 
@@ -234,6 +238,8 @@ class JMSSerializerExtensionTest extends TestCase
         $this->assertEquals(json_encode(array('name' => 'foo')), $serializer->serialize($versionedObject, 'json', SerializationContext::create()->setVersion('0.0.1')));
 
         $this->assertEquals(json_encode(array('name' => 'bar')), $serializer->serialize($versionedObject, 'json', SerializationContext::create()->setVersion('1.1.1')));
+
+        $this->assertEquals(json_encode(array('name' => 'foo')), $serializer->serialize($versionedObject, 'json', $container->get('JMS\Serializer\ContextFactory\SerializationContextFactoryInterface')->createSerializationContext()->setVersion('0.0.1')));
     }
 
     public function testLoadWithOptions()


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |