### PR TITLE
Allow to call `JsonSerializationVisitorFactory::setOptions()` with value `0`

### DIFF
--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -195,21 +195,20 @@ class JMSSerializerExtension extends ConfigurableExtension
     private function setVisitorOptions(array $config, ContainerBuilder $container): void
     {
         // json (serialization)
-        if (!empty($config['visitors']['json_serialization']['options'])) {
+        if (isset($config['visitors']['json_serialization']['options'])) {
             $container->getDefinition('jms_serializer.json_serialization_visitor')
                 ->addMethodCall('setOptions', [$config['visitors']['json_serialization']['options']]);
         }
-        if (!empty($config['visitors']['json_serialization']['depth'])) {
+        if (isset($config['visitors']['json_serialization']['depth'])) {
             $container->getDefinition('jms_serializer.json_serialization_visitor')
                 ->addMethodCall('setDepth', [$config['visitors']['json_serialization']['depth']]);
         }
 
         // json (deserialization)
-        if (!empty($config['visitors']['json_deserialization']['options'])) {
+        if (isset($config['visitors']['json_deserialization']['options'])) {
             $container->getDefinition('jms_serializer.json_deserialization_visitor')
                 ->addMethodCall('setOptions', [$config['visitors']['json_deserialization']['options']]);
         }
-
 
         // xml (serialization)
         if (!empty($config['visitors']['xml_serialization']['default_root_name'])) {

--- a/Tests/DependencyInjection/JMSSerializerExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSerializerExtensionTest.php
@@ -386,7 +386,68 @@ class JMSSerializerExtensionTest extends TestCase
             )
         ));
 
+        $configs[] = array(0, array(
+            'visitors' => array(
+                'json_serialization' => array(
+                    'options' => array(),
+                ),
+            ),
+        ));
+
+        $configs[] = array(JSON_PRESERVE_ZERO_FRACTION, array(
+            'visitors' => array(
+                'json_serialization' => array(
+                    'options' => 'JSON_PRESERVE_ZERO_FRACTION',
+                ),
+            ),
+        ));
+
         return $configs;
+    }
+
+    /**
+     * @dataProvider getJsonVisitorOptions
+     */
+    public function testPassJsonVisitorOptions(string $expected, $data, $options)
+    {
+        $container = $this->getContainerForConfig([
+            [
+                'visitors' => [
+                    'json_serialization' => [
+                        'options' => $options,
+                    ],
+                ],
+            ],
+        ]);
+        $serializer = $container->get('jms_serializer');
+
+        $this->assertSame($expected, $serializer->serialize($data, 'json'));
+    }
+
+    public function getJsonVisitorOptions()
+    {
+        return [
+            ['0', 0.0, 0],
+            ['0', 0.0, []],
+            ['0.0', 0.0, 'JSON_PRESERVE_ZERO_FRACTION'],
+        ];
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Expected either integer value or a array of the JSON_ constants.
+     */
+    public function testEmptyJsonVisitorOptions()
+    {
+        $this->getContainerForConfig([
+            [
+                'visitors' => [
+                    'json_serialization' => [
+                        'options' => null,
+                    ],
+                ],
+            ],
+        ]);
     }
 
     public function testExpressionLanguage()


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |yes   |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |

Without these changes, configuring the serializer with the following definition is not possible.
```yaml
jms_serializer:
    visitors:
        json_serialization:
            options: 0 # json_encode options bitmask, suggested JSON_PRETTY_PRINT in development
```