### PR TITLE
Make symfony/expression-language as non-dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
         "php": "^7.2",
         "jms/serializer": "^2.3|^3.0",
         "symfony/dependency-injection": "^3.3 || ^4.0",
+        "symfony/expression-language": "^3.0 || ^4.0",
         "symfony/framework-bundle": "^3.0 || ^4.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.4",
         "phpunit/phpunit": "^6.0",
-        "symfony/expression-language": "^3.0 || ^4.0",
         "symfony/finder": "^3.0 || ^4.0",
         "symfony/form": "^3.0 || ^4.0",
         "symfony/stopwatch": "^3.0 || ^4.0",


### PR DESCRIPTION
It is used within BasicSerializerFunctionsProvider that is being registered as a service