### PR TITLE
Added PHP 7.4 for tests in CI server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 php:
   - '7.2'
   - '7.3'
+  - '7.4'
 
 env:
   - SYMFONY_VERSION=^3.4 JMS_VERSION=^2.2


### PR DESCRIPTION
PHP 7.4 is out, via https://www.php.net/supported-versions.php