### PR TITLE
[doc] Removed confusing JSON_PRETTY_PRINT suggestion from json_deserialization

### DIFF
--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -237,7 +237,7 @@ values:
                     options: 0 # json_encode options bitmask, suggested JSON_PRETTY_PRINT in development
                     depth: 512
                 json_deserialization:
-                    options: 0 # json_encode options bitmask, suggested JSON_PRETTY_PRINT in development
+                    options: 0 # json_decode options bitmask
                 xml_serialization:
                     format_output: false
                     version: "1.0"


### PR DESCRIPTION
I was confused by the comment, as `JSON_PRETTY_PRINT` only makes sense for JSON serialization. After looking at the code, I don't see the deserialization visitor executing `json_encode()` anywhere. I propose to slightly modify the comment for `json_deserialization`