### PR TITLE
Use symfony decorators

### DIFF
--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -108,9 +108,11 @@ class JMSSerializerExtension extends ConfigurableExtension
             $container->setParameter('jms_serializer.infer_types_from_doctrine_metadata', false);
         }
 
-        if (PHP_VERSION_ID < 70400 || !class_exists(TypedPropertiesDriver::class)) {
-            $container
-                ->setAlias('jms_serializer.metadata_driver', new Alias('jms_serializer.metadata.chain_driver', true));
+        if (PHP_VERSION_ID >= 70400 && class_exists(TypedPropertiesDriver::class)) {
+            $container->getDefinition('jms_serializer.metadata.typed_properties_driver')
+                ->setDecoratedService('jms_serializer.metadata_driver')
+                ->setPublic(false)
+            ;
         }
 
         $container

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -72,26 +72,36 @@
             </argument>
         </service>
 
+        <!-- extra metadata driver -->
+        <service id="jms_serializer.metadata.doctrine_type_driver" class="JMS\Serializer\Metadata\Driver\DoctrineTypeDriver" public="false">
+            <argument />
+            <argument type="service" id="doctrine" />
+            <argument type="service" id="jms_serializer.type_parser" />
+        </service>
+        <service id="jms_serializer.metadata.doctrine_phpcr_type_driver" class="JMS\Serializer\Metadata\Driver\DoctrinePHPCRTypeDriver" public="false">
+            <argument />
+            <argument type="service" id="doctrine_phpcr" />
+            <argument type="service" id="jms_serializer.type_parser" />
+        </service>
         <service id="jms_serializer.metadata.typed_properties_driver" class="JMS\Serializer\Metadata\Driver\TypedPropertiesDriver" public="false">
-            <argument type="service" id="jms_serializer.metadata.chain_driver" />
+            <argument id="jms_serializer.metadata.typed_properties_driver.inner" type="service"/>
             <argument type="service" id="jms_serializer.type_parser" on-invalid="null" />
         </service>
 
-        <!-- extra metadata driver -->
-        <service id="jms_serializer.metadata.doctrine_type_driver" class="JMS\Serializer\Metadata\Driver\DoctrineTypeDriver" public="false">
-            <argument type="service" id="jms_serializer.metadata.chain_driver" />
-            <argument type="service" id="doctrine" />
-        </service>
-        <service id="jms_serializer.metadata.doctrine_phpcr_type_driver" class="JMS\Serializer\Metadata\Driver\DoctrinePHPCRTypeDriver" public="false">
-            <argument type="service" id="jms_serializer.metadata.chain_driver" />
-            <argument type="service" id="doctrine_phpcr" />
-        </service>
-        <service id="jms_serializer.metadata.lazy_loading_driver" class="Metadata\Driver\LazyLoadingDriver" public="false">
-            <argument type="service" id="service_container" />
-            <argument>jms_serializer.metadata_driver</argument>
+        <service id="jms_serializer.metadata.service_locator" class="Symfony\Component\DependencyInjection\ServiceLocator" public="false">
+            <argument type="collection">
+                <argument key="metadata_driver" type="service" id="jms_serializer.metadata_driver" />
+            </argument>
+
+            <tag name="container.service_locator" />
         </service>
 
-        <service id="jms_serializer.metadata_driver" alias="jms_serializer.metadata.typed_properties_driver" public="true"/>
+        <service id="jms_serializer.metadata.lazy_loading_driver" class="Metadata\Driver\LazyLoadingDriver" public="false">
+            <argument type="service" id="jms_serializer.metadata.service_locator"/>
+            <argument>metadata_driver</argument>
+        </service>
+
+        <service id="jms_serializer.metadata_driver" alias="jms_serializer.metadata.chain_driver" public="true"/>
 
         <!-- Metadata Factory -->
         <service id="jms_serializer.metadata.cache.file_cache" class="Metadata\Cache\FileCache" public="false">

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require": {
         "php": "^7.2",
         "jms/serializer": "^3.0",
+        "jms/metadata": "^2.3",
         "symfony/dependency-injection": "^3.3 || ^4.0 || ^5.0",
         "symfony/framework-bundle": "^3.0 || ^4.0 || ^5.0"
     },


### PR DESCRIPTION
Use symfony decorators to decorate metadata drivers and object constructors.

This simplifies a lot the code and makes possible a better decoration process. the previous implementation was self-implementing the decoration process