### PR TITLE
Update installation guide to include Flex based apps

### DIFF
--- a/Resources/doc/installation.rst
+++ b/Resources/doc/installation.rst
@@ -18,8 +18,30 @@ of the Composer documentation.
 Step 2: Enable the Bundle
 -------------------------
 
-Then, enable the bundle by adding the following line in the ``app/AppKernel.php``
-file of your project:
+Symfony Flex Applications
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For an application using Symfony Flex, the bundle should be automatically
+enabled. If it is not, you will need to add it to the ``config/bundles.php``
+file in your project:
+
+.. code-block:: php
+
+    <?php
+    // config/bundles.php
+
+    return [
+        // ...
+        JMS\SerializerBundle\JMSSerializerBundle::class => ['all' => true],
+    ];
+
+
+Symfony Standard Applications
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For an application based on the Symfony Standard structure, you will need to
+enable the bundle in your Kernel by adding the following line in the
+``app/AppKernel.php`` file in your project:
 
 .. code-block:: php
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | N/A
| Fixed tickets | partially #865
| License       | MIT

The install guide only shows information for older "Symfony Standard Edition" applications.  This adds info for Flex-based applications.