### PR TITLE
Fix compatibility with PHP 8.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
         dependencies:
           - "highest"
         include:

--- a/DependencyInjection/Compiler/ServiceMapPass.php
+++ b/DependencyInjection/Compiler/ServiceMapPass.php
@@ -63,11 +63,21 @@ final class ServiceMapPass implements CompilerPassInterface, \Serializable
 
     public function serialize()
     {
-        return serialize([$this->tagName, $this->keyAttributeName]);
+        return serialize($this->__serialize());
     }
 
     public function unserialize($str)
     {
-        [$this->tagName, $this->keyAttributeName] = unserialize($str);
+        $this->__unserialize((array) unserialize((string) $str));
+    }
+
+    public function __serialize(): array
+    {
+        return [$this->tagName, $this->keyAttributeName];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        [$this->tagName, $this->keyAttributeName] = $data;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

Run tests against PHP 8.1 and fix deprecation warning because of deprecated `Serializeable` interface (https://wiki.php.net/rfc/phase_out_serializable)