### PR TITLE
Add doc blocks to silence Symfony deprecations

### DIFF
--- a/Cache/CacheWarmer.php
+++ b/Cache/CacheWarmer.php
@@ -35,6 +35,8 @@ class CacheWarmer implements CacheWarmerInterface
 
     /**
      * @param string $cacheDir
+     *
+     * @return string[] A list of classes or files to preload on PHP 7.4+
      */
     public function warmUp($cacheDir)
     {
@@ -52,6 +54,8 @@ class CacheWarmer implements CacheWarmerInterface
                 $this->metadataFactory->getMetadataForClass($class);
             }
         }
+
+        return [];
     }
 
     public function isOptional(): bool

--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -10,6 +10,7 @@ use JMS\Serializer\Handler\SubscribingHandlerInterface;
 use JMS\Serializer\Metadata\Driver\AttributeDriver\AttributeReader;
 use JMS\Serializer\Metadata\Driver\DocBlockDriver;
 use JMS\Serializer\Metadata\Driver\TypedPropertiesDriver;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -205,6 +206,9 @@ class JMSSerializerExtension extends ConfigurableExtension
         }
     }
 
+    /**
+     * @return ConfigurationInterface
+     */
     public function getConfiguration(array $config, ContainerBuilder $container)
     {
         return new Configuration($container->getParameterBag()->resolveValue('%kernel.debug%'));

--- a/ExpressionLanguage/BasicSerializerFunctionsProvider.php
+++ b/ExpressionLanguage/BasicSerializerFunctionsProvider.php
@@ -9,6 +9,9 @@ use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
 
 class BasicSerializerFunctionsProvider implements ExpressionFunctionProviderInterface
 {
+    /**
+     * @return ExpressionFunction[]
+     */
     public function getFunctions()
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

Adds a couple of doc blocks to silence Symfony's `DebugClassLoader` when run on Symfony 5.4+