### PR TITLE
Run `TwigExtensionPass` with higher priority

### DIFF
--- a/JMSSerializerBundle.php
+++ b/JMSSerializerBundle.php
@@ -30,8 +30,10 @@ class JMSSerializerBundle extends Bundle
             }
         ));
 
+        // Should run before Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\TwigEnvironmentPass
+        $builder->addCompilerPass(new TwigExtensionPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 10);
+
         $builder->addCompilerPass(new FormErrorHandlerTranslationDomainPass());
-        $builder->addCompilerPass(new TwigExtensionPass());
         $builder->addCompilerPass(new ExpressionFunctionProviderPass());
         $builder->addCompilerPass(new DoctrinePass());
 


### PR DESCRIPTION
When `TwigBundle` is added before `JMSSerializerBundle` in `bundles.php` the following errors occurs:

```
In CheckExceptionOnInvalidReferenceBehaviorPass.php line 86:

  The service "twig" has a dependency on a non-existent service "jms_serializer.twig_extension.serializer". Did you mean one of these: "jms_serializer.twig_ext
  ension.runtime_serializer", "jms_serializer.twig_extension.serializer_runtime_helper"?

```

This is happening because the `TwigEnvironmentPass` finds all services tagged with `twig.extension`.
Then the `TwigExtensionPass` of JMSSerializerBundle removes the extension. This leaves `twig` service
with a reference to an unknown service.

