### PR TITLE
Fixed dev toolbar styling issue

### DIFF
--- a/Resources/views/Collector/panel.html.twig
+++ b/Resources/views/Collector/panel.html.twig
@@ -4,8 +4,10 @@
 
     {%- set icon -%}
         {{- include('@JMSSerializer/icon.svg') }}
-        <span class="sf-toolbar-label">S:</span>{{- collector.runs(1)|length }}
-        <span class="sf-toolbar-label">D:</span>{{- collector.runs(2)|length }}
+        <span class="sf-toolbar-label">S:</span>
+        <span class="sf-toolbar-value">{{- collector.runs(1)|length }}</span>
+        <span class="sf-toolbar-label">D:</span>
+        <span class="sf-toolbar-value">{{- collector.runs(2)|length }}</span>
     {%- endset -%}
 
     {%- set text -%}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

This PR fixes a minor alignment issue in the dev toolbar

Before:

<img width="233" alt="Screenshot 2022-03-02 at 08 45 49" src="https://user-images.githubusercontent.com/1374857/156318529-a45e22d4-1b6e-4c4f-b6a7-9a028614ae04.png">

After:

<img width="241" alt="image" src="https://user-images.githubusercontent.com/1374857/156318466-c087ac3a-63e5-48a8-8237-5e5036d5ecfd.png">



