### PR TITLE
Support modern bundle structure

### DIFF
--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -16,12 +16,19 @@ class ConfigurationTest extends TestCase
 {
     private function getContainer(array $configs = [])
     {
+        $bundles = ['JMSSerializerBundle' => 'JMS\SerializerBundle\JMSSerializerBundle'];
         $container = new ContainerBuilder();
 
         $container->set('annotation_reader', new AnnotationReader());
         $container->setParameter('kernel.debug', true);
         $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/serializer');
-        $container->setParameter('kernel.bundles', ['JMSSerializerBundle' => 'JMS\SerializerBundle\JMSSerializerBundle']);
+        $container->setParameter('kernel.bundles', $bundles);
+        $container->setParameter('kernel.bundles_metadata', array_map(static function (string $class): array {
+            return [
+                'path' => (new $class)->getPath(),
+                'namespace' => (new \ReflectionClass($class))->getNamespaceName(),
+            ];
+        }, $bundles));
 
         $bundle = new JMSSerializerBundle();
 

--- a/Tests/DependencyInjection/CustomHandlerPassTest.php
+++ b/Tests/DependencyInjection/CustomHandlerPassTest.php
@@ -27,7 +27,7 @@ class CustomHandlerPassTest extends TestCase
         $container->setParameter('kernel.debug', true);
         $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/serializer');
         $container->setParameter('kernel.bundles', []);
-        $container->setParameter('kernel.bundles', []);
+        $container->setParameter('kernel.bundles_metadata', []);
 
         $loader->load(['jms_serializer' => $configs], $container);
 

--- a/Tests/DependencyInjection/DoctrinePassTest.php
+++ b/Tests/DependencyInjection/DoctrinePassTest.php
@@ -25,6 +25,7 @@ class DoctrinePassTest extends TestCase
         $container->setParameter('kernel.debug', true);
         $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/serializer');
         $container->setParameter('kernel.bundles', []);
+        $container->setParameter('kernel.bundles_metadata', []);
 
         $pass = new DoctrinePass();
         $container->addCompilerPass($pass);

--- a/Tests/DependencyInjection/EventSubscribersAndListenersPassTest.php
+++ b/Tests/DependencyInjection/EventSubscribersAndListenersPassTest.php
@@ -27,7 +27,7 @@ class EventSubscribersAndListenersPassTest extends TestCase
         $container->setParameter('kernel.debug', true);
         $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/serializer');
         $container->setParameter('kernel.bundles', []);
-        $container->setParameter('kernel.bundles', []);
+        $container->setParameter('kernel.bundles_metadata', []);
 
         $loader->load(['jms_serializer' => $configs], $container);
 

--- a/Tests/DependencyInjection/FormErrorHandlerTranslationDomainPassTest.php
+++ b/Tests/DependencyInjection/FormErrorHandlerTranslationDomainPassTest.php
@@ -24,6 +24,7 @@ class FormErrorHandlerTranslationDomainPassTest extends TestCase
         $container->setParameter('kernel.debug', true);
         $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/serializer');
         $container->setParameter('kernel.bundles', []);
+        $container->setParameter('kernel.bundles_metadata', []);
 
         $loader->load(['jms_serializer' => $configs], $container);
 

--- a/Tests/DependencyInjection/JMSSerializerExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSerializerExtensionTest.php
@@ -793,6 +793,7 @@ class JMSSerializerExtensionTest extends TestCase
         $container->setParameter('kernel.debug', true);
         $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/serializer');
         $container->setParameter('kernel.bundles', []);
+        $container->setParameter('kernel.bundles_metadata', []);
         $container->setParameter('foo', 'bar');
         $container->set('annotation_reader', new AnnotationReader());
         $container->setDefinition('doctrine', new Definition(Registry::class));

--- a/Tests/DependencyInjection/NamingStrategyTest.php
+++ b/Tests/DependencyInjection/NamingStrategyTest.php
@@ -25,6 +25,7 @@ class NamingStrategyTest extends TestCase
         $container->setParameter('kernel.debug', true);
         $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/serializer');
         $container->setParameter('kernel.bundles', []);
+        $container->setParameter('kernel.bundles_metadata', []);
 
         $loader->load(['jms_serializer' => $configs], $container);
 

--- a/Tests/DependencyInjection/TwigExtensionPassTest.php
+++ b/Tests/DependencyInjection/TwigExtensionPassTest.php
@@ -23,6 +23,12 @@ class TwigExtensionPassTest extends TestCase
         $container->setParameter('kernel.debug', true);
         $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/serializer');
         $container->setParameter('kernel.bundles', $bundles);
+        $container->setParameter('kernel.bundles_metadata', array_map(static function (string $class): array {
+            return [
+                'path' => (new $class)->getPath(),
+                'namespace' => (new \ReflectionClass($class))->getNamespaceName(),
+            ];
+        }, $bundles));
 
         $loader->load([[]], $container);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | depends
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #...
| License       | MIT


Symfony changed its "Directory Structure Best Practice for Reusable Bundles" in its 4.4 version.

In the old one, everything was just in the bundle root dir `/` (or maybe inside `/src`, in which case this was considered "root").
In the new one, the PHP classes moved inside `/src` and the contents of `/Resources` are unpacked into the root `/` (with sometimes different names).

Below is a comparison of the old and the new structure:

<table>
<thead align="center">
<td><a href="https://symfony.com/doc/4.3/bundles/best_practices.html#directory-structure">Symfony < 4.4</a></td>
<td><a href="https://symfony.com/doc/4.4/bundles/best_practices.html#directory-structure">Symfony >= 4.4</a></td>
</thead>
<tr>
<td valign="top">
<pre>
/
├─ AcmeBlogBundle.php
├─ Controller/
├─ README.md
├─ LICENSE
├─ Resources/
│  ├─ config/
│  ├─ doc/
│  │  └─ index.rst
│  ├─ translations/
│  ├─ views/
│  └─ public/
└─ Tests/
</pre>
</td>
<td valign="top">
<pre>
/
├─ config/
├─ docs/
│  └─ index.md
├─ public/
├─ src/
│  ├─ Controller/
│  ├─ DependencyInjection/
│  └─ AcmeBlogBundle.php
├─ templates/
├─ tests/
├─ translations/
├─ LICENSE
└─ README.md
<pre>
</td>
</tr>
</table>

JMSSerializerBundle doesn't support the new bundle structure when doing metadata autodetection at the moment, because it doesn't look at the new location for the serializer config, which would be `/config/serializer` instead of `/Resources/config/serializer`. The solution is to look in both possible location, as Symfony does e.g. [here](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bundle/TwigBundle/TemplateIterator.php#L69), [here](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php#L178), [here](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php#L139) or [here](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L1365).

Explicitly configured metadata directories don't work either, because JMSSerializerBundle assumes the `*Bundle` class as the bundle root (instead of using the value returned by `*Bundle::getPath()` ([as described here](https://symfony.com/doc/4.4/bundles/best_practices.html#directory-structure))) which means for the new bundle structure one has to currently use `@MyBundle/../config/serializer` because the `*Bundle` class is inside the `/src` folder. After this PR got merged, it would be `@MyBundle/config/serializer`, which could be considered as a BC break, although I'd say it is a bugfix.