### PR TITLE
Fix `TraceableFileLocator`

### DIFF
--- a/Debug/TraceableFileLocator.php
+++ b/Debug/TraceableFileLocator.php
@@ -3,6 +3,7 @@
 namespace JMS\SerializerBundle\Debug;
 
 use Metadata\Driver\AdvancedFileLocatorInterface;
+use Metadata\Driver\TraceableFileLocatorInterface;
 
 /**
  * @internal
@@ -29,8 +30,10 @@ final class TraceableFileLocator implements AdvancedFileLocatorInterface
     {
         $path = $this->decorated->findFileForClass($class, $extension);
 
-        if ($path !== null) {
-            $this->files[$class->getName()][] = $path;
+        if ($this->decorated instanceof TraceableFileLocatorInterface) {
+            $this->files[$class->getName()] = array_merge($this->files[$class->getName()] ?? [], $this->decorated->getPossibleFilesForClass($class, $extension));
+        } elseif ($path !== null) {
+            $this->files[$class->getName()][$path] = true;
         }
 
         return $path;

--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -164,7 +164,7 @@ class JMSSerializerExtension extends ConfigurableExtension
         $directories = $this->detectMetadataDirectories($config['metadata'], $bundles);
 
         $container
-            ->findDefinition('jms_serializer.metadata.file_locator')
+            ->getDefinition('jms_serializer.metadata.file_locator')
             ->replaceArgument(0, $directories);
 
         if ($config['profiler']) {

--- a/Resources/config/debug.xml
+++ b/Resources/config/debug.xml
@@ -11,7 +11,7 @@
             <argument type="service" id="jms_serializer.event_dispatcher"/>
             <argument type="service" id="jms_serializer.traceable_handler_registry"/>
             <argument type="service" id="jms_serializer.traceable_metadata_factory"/>
-            <argument type="service" id="jms_serializer.metadata.traceable_file_locator"/>
+            <argument type="service" id="jms_serializer.metadata.file_locator"/>
             <argument type="service" id="jms_serializer.traceable_runs_listener"/>
 
             <tag name="data_collector"

--- a/Resources/config/debug.xml
+++ b/Resources/config/debug.xml
@@ -11,7 +11,7 @@
             <argument type="service" id="jms_serializer.event_dispatcher"/>
             <argument type="service" id="jms_serializer.traceable_handler_registry"/>
             <argument type="service" id="jms_serializer.traceable_metadata_factory"/>
-            <argument type="service" id="jms_serializer.metadata.file_locator"/>
+            <argument type="service" id="jms_serializer.metadata.traceable_file_locator"/>
             <argument type="service" id="jms_serializer.traceable_runs_listener"/>
 
             <tag name="data_collector"
@@ -47,11 +47,13 @@
             <argument type="service" id="jms_serializer.traceable_handler_registry.inner"/>
         </service>
 
-        <service id="jms_serializer.metadata.traceable_file_locator" class="JMS\SerializerBundle\Debug\TraceableFileLocator" public="false">
-            <argument type="collection" /><!-- Namespace Prefixes mapping to Directories -->
-        </service>
-
-        <service id="jms_serializer.metadata.file_locator" alias="jms_serializer.metadata.traceable_file_locator">
+        <service
+                id="jms_serializer.metadata.traceable_file_locator"
+                class="JMS\SerializerBundle\Debug\TraceableFileLocator"
+                decorates="jms_serializer.metadata.file_locator"
+                decoration-priority="-128"
+                public="false">
+            <argument type="service" id="jms_serializer.metadata.traceable_file_locator.inner"/>
         </service>
 
         <service id="jms_serializer.event_dispatcher" alias="jms_serializer.traceable_event_dispatcher">

--- a/Resources/views/Collector/metadata.html.twig
+++ b/Resources/views/Collector/metadata.html.twig
@@ -5,12 +5,6 @@
         <p>No metadata have been loaded.</p>
     </div>
 {%- else -%}
-{#    <div>#}
-{#        <div class="sf-toolbar-info-piece">#}
-{#            <b>Runs</b>#}
-{#            <span class="sf-toolbar-status">{{ collector.loadedMetadata|length }}</span>#}
-{#        </div>#}
-{#    </div>#}
 
     <table>
         <thead>
@@ -32,6 +26,7 @@
     </table>
 {%- endif -%}
 
+
 <h3>Attempted files</h3>
 {%- if collector.metadataFiles is empty -%}
     <div class="empty">
@@ -49,8 +44,10 @@
             <tr>
                 <td>{{ class }}</td>
                 <td nowrap="nowrap">
-                    {%- for file in files -%}
-                        {{ file }}<br/>
+                    {%- for file, found in files -%}
+                        <span style="color: {{ found ? 'green': 'red' }}">
+                        {{ file }} ({{ found ? 'found': 'not found' }})<br/>
+                        </span>
                     {% endfor %}
                 </td>
             </tr>

--- a/Resources/views/Collector/metadata.html.twig
+++ b/Resources/views/Collector/metadata.html.twig
@@ -32,15 +32,12 @@
     </table>
 {%- endif -%}
 
-
 <h3>Attempted files</h3>
 {%- if collector.metadataFiles is empty -%}
     <div class="empty">
         <p>No metadata files attempted (if this list is empty, probably all the data are cached as expected)</p>
     </div>
 {%- else -%}
-
-
     <table>
         <thead>
         <tr>
@@ -52,10 +49,8 @@
             <tr>
                 <td>{{ class }}</td>
                 <td nowrap="nowrap">
-                    {%- for file, found in files -%}
-                        <span style="color: {{ found ? 'green': 'red' }}">
-                        {{ file }} ({{ found ? 'found': 'not found' }})<br/>
-                        </span>
+                    {%- for file in files -%}
+                        {{ file }}<br/>
                     {% endfor %}
                 </td>
             </tr>

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -17,7 +17,7 @@ class ConfigurationTest extends TestCase
     private function getContainer(array $configs = [])
     {
         $container = new ContainerBuilder();
-        
+
         $container->set('annotation_reader', new AnnotationReader());
         $container->setParameter('kernel.debug', true);
         $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/serializer');
@@ -27,7 +27,7 @@ class ConfigurationTest extends TestCase
 
         $extension = $bundle->getContainerExtension();
         $extension->load($configs, $container);
-        
+
         return $container;
     }
 
@@ -115,6 +115,7 @@ class ConfigurationTest extends TestCase
         $this->assertArrayNotHasKey('JMSSerializerBundleNs1', $directories);
         $this->assertEquals($ref->getPath() . '/Resources/config', $directories['JMSSerializerBundleNs2']);
     }
+
     public function testDebugWithoutCache()
     {
         $container = $this->getContainer([
@@ -132,10 +133,10 @@ class ConfigurationTest extends TestCase
             ],
         ]);
         $container->compile();
-        
+
         $this->assertNotEmpty($container->get('jms_serializer'));
     }
-    
+
     public function testContextDefaults()
     {
         $processor = new Processor();

--- a/Tests/DependencyInjection/JMSSerializerExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSerializerExtensionTest.php
@@ -300,11 +300,11 @@ class JMSSerializerExtensionTest extends TestCase
                 ],
             ],
         ], static function (ContainerBuilder $container) {
-            $container->getAlias('jms_serializer.metadata.file_locator')->setPublic(true);
+            $container->findDefinition('jms_serializer.metadata.file_locator')->setPublic(true);
         });
 
         $fileLocatorDef = $container->findDefinition('jms_serializer.metadata.file_locator');
-        $directories = $fileLocatorDef->getArgument(0);
+        $directories = $fileLocatorDef->getArgument(0)->getArgument(0);
         $this->assertEquals(['foo_ns' => __DIR__], $directories);
     }
 
@@ -674,7 +674,7 @@ class JMSSerializerExtensionTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    private function getContainerForConfigLoad(array $configs, ?callable $configurator = null)
+    private function getContainerForConfigLoad(array $configs)
     {
         $bundle = new JMSSerializerBundle();
         $extension = $bundle->getContainerExtension();
@@ -699,7 +699,7 @@ class JMSSerializerExtensionTest extends TestCase
 
     private function getContainerForConfig(array $configs, ?callable $configurator = null)
     {
-        $container = $this->getContainerForConfigLoad($configs, $configurator);
+        $container = $this->getContainerForConfigLoad($configs);
 
         if ($configurator) {
             call_user_func($configurator, $container);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #858
| License       | MIT

The `TraceableFileLocator`, which was introduced in #858, to log some data for Symfony's profiler panel, was broken. It implemented a method that doesn't exist anywhere in the project and thus never gets called, so nothing is logged. In the profiler panel you may think everything's alright, though, as the message `if this list is empty, probably all the data are cached as expected` gets displayed, which is probably even true most of the time.

The new `TraceableFileLocator` now also decorates the original one, instead of extending it, which makes it more flexible in case someone else wants to decorate the `FileLocator`, too.