### PR TITLE
Disable profiler when debug is disabled

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -35,7 +35,11 @@ class Configuration implements ConfigurationInterface
             $root = $tb->root('jms_serializer')->children();
         }
 
-        $root->booleanNode('profiler')->defaultTrue($this->debug)->end();
+        if ($this->debug) {
+            $root->booleanNode('profiler')->defaultTrue()->end();
+        } else {
+            $root->booleanNode('profiler')->defaultFalse()->end();
+        }
 
         $this->addHandlersSection($root);
         $this->addSubscribersSection($root);


### PR DESCRIPTION
defaultTrue does not accept any arguments
So profiller is enable by default and this is very bad for production

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

