### PR TITLE
Allow `dealerdirect/phpcodesniffer-composer-installer` plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,10 @@
         "symfony/finder": "Required for cache warmup, supported versions ^3.0|^4.0"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Fixes an error in the CI pipeline during `composer install`:

```
Error: dealerdirect/phpcodesniffer-composer-installer contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.
You can run "composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer [true|false]" to enable it (true) or disable it explicitly and suppress this exception (false)
See https://getcomposer.org/allow-plugins

In PluginManager.php line 744:
                                                                               
  dealerdirect/phpcodesniffer-composer-installer contains a Composer plugin w hich is blocked by your allow-plugins config. You may add it to the list if you consider it safe.                                                       
  You can run "composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer [true|false]" to enable it (true) or disable it explicitly and suppress this exception (false)                              
  See https://getcomposer.org/allow-plugins
                                    
```

It's a dependency of `doctrine/coding-standard`:

```sh
> composer why dealerdirect/phpcodesniffer-composer-installer
doctrine/coding-standard 8.2.1 requires dealerdirect/phpcodesniffer-composer-installer (^0.6.2 || ^0.7) 
slevomat/coding-standard 6.4.1 requires dealerdirect/phpcodesniffer-composer-installer (^0.6.2 || ^0.7) 
```

---

Probably all pipelines will fail until this is resolved. See #894, #893.