### PR TITLE
Add support for injecting the expression evaluator into metadata drivers

### DIFF
--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -6,6 +6,7 @@ namespace JMS\SerializerBundle\DependencyInjection;
 
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\Exception\RuntimeException;
+use JMS\Serializer\Expression\CompilableExpressionEvaluatorInterface;
 use JMS\Serializer\Handler\SubscribingHandlerInterface;
 use JMS\Serializer\Handler\SymfonyUidHandler;
 use JMS\Serializer\Metadata\Driver\AttributeDriver\AttributeReader;
@@ -143,6 +144,20 @@ final class JMSSerializerExtension extends Extension
             $container
                 ->getDefinition('jms_serializer.accessor_strategy.default')
                 ->replaceArgument(0, new Reference($config['expression_evaluator']['id']));
+
+            if (is_a($container->findDefinition($config['expression_evaluator']['id'])->getClass(), CompilableExpressionEvaluatorInterface::class, true)) {
+                $container
+                    ->getDefinition('jms_serializer.metadata.yaml_driver')
+                    ->replaceArgument(3, new Reference($config['expression_evaluator']['id']));
+
+                $container
+                    ->getDefinition('jms_serializer.metadata.xml_driver')
+                    ->replaceArgument(3, new Reference($config['expression_evaluator']['id']));
+
+                $container
+                    ->getDefinition('jms_serializer.metadata.annotation_driver')
+                    ->replaceArgument(3, new Reference($config['expression_evaluator']['id']));
+            }
         } else {
             $container->removeDefinition('jms_serializer.expression_evaluator');
         }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -91,16 +91,19 @@
             <argument type="service" id="jms_serializer.metadata.file_locator" />
             <argument type="service" id="jms_serializer.naming_strategy" />
             <argument type="service" id="jms_serializer.type_parser" on-invalid="null" />
+            <argument type="constant">NULL</argument> <!-- expression evaluator -->
         </service>
         <service id="jms_serializer.metadata.xml_driver" class="JMS\Serializer\Metadata\Driver\XmlDriver" public="false">
             <argument type="service" id="jms_serializer.metadata.file_locator" />
             <argument type="service" id="jms_serializer.naming_strategy" />
             <argument type="service" id="jms_serializer.type_parser" on-invalid="null" />
+            <argument type="constant">NULL</argument> <!-- expression evaluator -->
         </service>
         <service id="jms_serializer.metadata.annotation_driver" class="JMS\Serializer\Metadata\Driver\AnnotationDriver" public="false">
             <argument type="service" id="annotation_reader" />
             <argument type="service" id="jms_serializer.naming_strategy" />
             <argument type="service" id="jms_serializer.type_parser" on-invalid="null" />
+            <argument type="constant">NULL</argument> <!-- expression evaluator -->
         </service>
         <service id="jms_serializer.metadata_driver" class="Metadata\Driver\DriverChain" public="false">
             <argument type="collection">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

Right now, without adding a compiler pass in a downstream application, the metadata drivers can't receive an expression evaluator.  This adds support for injecting the configured evaluator as long as the service implements `JMS\Serializer\Expression\CompilableExpressionEvaluatorInterface`.