### PR TITLE
Use tags for the metadata drivers and a compiler pass to register them to the driver chain in priority order

### DIFF
--- a/DependencyInjection/Compiler/AddMetadataDriversToChainPass.php
+++ b/DependencyInjection/Compiler/AddMetadataDriversToChainPass.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMS\SerializerBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+/**
+ * @internal
+ */
+final class AddMetadataDriversToChainPass implements CompilerPassInterface
+{
+    use PriorityTaggedServiceTrait;
+
+    public function process(ContainerBuilder $container): void
+    {
+        try {
+            $chainDefinition = $container->findDefinition('jms_serializer.metadata_driver');
+
+            foreach ($this->findAndSortTaggedServices('jms_serializer.metadata_driver', $container) as $driver) {
+                $chainDefinition->addMethodCall('addDriver', [$driver]);
+            }
+        } catch (ServiceNotFoundException $exception) {
+        }
+    }
+}

--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -44,23 +44,9 @@ final class JMSSerializerExtension extends Extension
             $loader->load('debug.xml');
         }
 
-        $metadataDrivers = [
-            new Reference('jms_serializer.metadata.yaml_driver'),
-            new Reference('jms_serializer.metadata.xml_driver'),
-            new Reference('jms_serializer.metadata.annotation_driver'),
-        ];
-
         // enable the attribute driver on php 8
         if (PHP_VERSION_ID >= 80000) {
-            if (class_exists(AttributeDriver::class)) {
-                // Register the attribute driver before the annotation driver
-                $metadataDrivers = [
-                    new Reference('jms_serializer.metadata.yaml_driver'),
-                    new Reference('jms_serializer.metadata.xml_driver'),
-                    new Reference('jms_serializer.metadata.attribute_driver'),
-                    new Reference('jms_serializer.metadata.annotation_driver'),
-                ];
-            } else {
+            if (!class_exists(AttributeDriver::class)) {
                 $container->removeDefinition('jms_serializer.metadata.attribute_driver');
 
                 if (class_exists(AttributeReader::class)) {
@@ -74,10 +60,6 @@ final class JMSSerializerExtension extends Extension
         } else {
             $container->removeDefinition('jms_serializer.metadata.attribute_driver');
         }
-
-        $container
-            ->getDefinition('jms_serializer.metadata_driver')
-            ->replaceArgument(0, $metadataDrivers);
 
         DIUtils::cloneDefinitions($container, array_keys($configs['instances']));
 

--- a/JMSSerializerBundle.php
+++ b/JMSSerializerBundle.php
@@ -2,6 +2,7 @@
 
 namespace JMS\SerializerBundle;
 
+use JMS\SerializerBundle\DependencyInjection\Compiler\AddMetadataDriversToChainPass;
 use JMS\SerializerBundle\DependencyInjection\Compiler\AdjustDecorationPass;
 use JMS\SerializerBundle\DependencyInjection\Compiler\CustomHandlersPass;
 use JMS\SerializerBundle\DependencyInjection\Compiler\DoctrinePass;
@@ -26,6 +27,7 @@ class JMSSerializerBundle extends Bundle
         $builder->addCompilerPass(new FormErrorHandlerTranslationDomainPass());
         $builder->addCompilerPass(new ExpressionFunctionProviderPass());
         $builder->addCompilerPass(new DoctrinePass());
+        $builder->addCompilerPass(new AddMetadataDriversToChainPass());
 
         $builder->addCompilerPass(new RegisterEventListenersAndSubscribersPass(), PassConfig::TYPE_OPTIMIZE);
         $builder->addCompilerPass(new CustomHandlersPass(), PassConfig::TYPE_OPTIMIZE);

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -100,29 +100,29 @@
             <argument type="service" id="jms_serializer.naming_strategy" />
             <argument type="service" id="jms_serializer.type_parser" on-invalid="null" />
             <argument type="constant">NULL</argument> <!-- expression evaluator -->
+            <tag name="jms_serializer.metadata_driver" priority="40"/>
         </service>
         <service id="jms_serializer.metadata.xml_driver" class="JMS\Serializer\Metadata\Driver\XmlDriver" public="false">
             <argument type="service" id="jms_serializer.metadata.file_locator" />
             <argument type="service" id="jms_serializer.naming_strategy" />
             <argument type="service" id="jms_serializer.type_parser" on-invalid="null" />
             <argument type="constant">NULL</argument> <!-- expression evaluator -->
+            <tag name="jms_serializer.metadata_driver" priority="30"/>
         </service>
         <service id="jms_serializer.metadata.annotation_driver" class="JMS\Serializer\Metadata\Driver\AnnotationDriver" public="false">
             <argument type="service" id="annotation_reader" />
             <argument type="service" id="jms_serializer.naming_strategy" />
             <argument type="service" id="jms_serializer.type_parser" on-invalid="null" />
             <argument type="constant">NULL</argument> <!-- expression evaluator -->
+            <tag name="jms_serializer.metadata_driver" priority="10"/>
         </service>
         <service id="jms_serializer.metadata.attribute_driver" class="JMS\Serializer\Metadata\Driver\AttributeDriver" public="false">
             <argument type="service" id="jms_serializer.naming_strategy" />
             <argument type="service" id="jms_serializer.type_parser" on-invalid="null" />
             <argument type="constant">NULL</argument> <!-- expression evaluator -->
+            <tag name="jms_serializer.metadata_driver" priority="20"/>
         </service>
-        <service id="jms_serializer.metadata_driver" class="Metadata\Driver\DriverChain" public="false">
-            <argument type="collection">
-                <argument type="constant">NULL</argument> <!-- list of metadata drivers -->
-            </argument>
-        </service>
+        <service id="jms_serializer.metadata_driver" class="Metadata\Driver\DriverChain" public="false" />
 
         <!-- extra metadata driver -->
         <service id="jms_serializer.metadata.doctrine_type_driver" class="JMS\Serializer\Metadata\Driver\DoctrineTypeDriver" public="false">

--- a/Tests/DependencyInjection/AddMetadataDriversToChainPassTest.php
+++ b/Tests/DependencyInjection/AddMetadataDriversToChainPassTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DependencyInjection;
+
+use JMS\Serializer\Metadata\Driver\AnnotationDriver;
+use JMS\Serializer\Metadata\Driver\XmlDriver;
+use JMS\Serializer\Metadata\Driver\YamlDriver;
+use JMS\SerializerBundle\DependencyInjection\Compiler\AddMetadataDriversToChainPass;
+use Metadata\Driver\DriverChain;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class AddMetadataDriversToChainPassTest extends TestCase
+{
+    public function testAddsTaggedMetadataDriversToTheChain()
+    {
+        $container = new ContainerBuilder();
+
+        $chainDefinition = $container->register('jms_serializer.metadata_driver', DriverChain::class);
+
+        $container->register('jms_serializer.metadata.yaml_driver', YamlDriver::class)
+            ->addTag('jms_serializer.metadata_driver', ['priority' => 30]);
+
+        $container->register('jms_serializer.metadata.xml_driver', XmlDriver::class)
+            ->addTag('jms_serializer.metadata_driver', ['priority' => 20]);
+
+        $container->register('jms_serializer.metadata.annotation_driver', AnnotationDriver::class)
+            ->addTag('jms_serializer.metadata_driver', ['priority' => 10]);
+
+        (new AddMetadataDriversToChainPass())->process($container);
+
+        $this->assertCount(3, $chainDefinition->getMethodCalls());
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testDoesNothingIfTheDriverChainIsNotRegistered()
+    {
+        (new AddMetadataDriversToChainPass())->process(new ContainerBuilder());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

The list of metadata drivers added to the `jms_serializer.metadata_driver` service is hardcoded into its definition right now.  To give a little more flexibility to the chain, let's use tagged services and the ability to set priorities on those instead.  This makes it easier for developers to register their own custom metadata drivers or remove drivers in their applications.