### PR TITLE
Add return types to silence Symfony 6.3 deprecation notices

### DIFF
--- a/Debug/DataCollector.php
+++ b/Debug/DataCollector.php
@@ -42,7 +42,7 @@ final class DataCollector extends BaseDataCollector implements LateDataCollector
         $this->reset();
     }
 
-    public function collect(Request $request, Response $response, \Throwable $exception = null)
+    public function collect(Request $request, Response $response, \Throwable $exception = null): void
     {
     }
 

--- a/DependencyInjection/Compiler/AdjustDecorationPass.php
+++ b/DependencyInjection/Compiler/AdjustDecorationPass.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 final class AdjustDecorationPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         DIUtils::adjustDecorators($container);
     }

--- a/DependencyInjection/Compiler/PerInstancePass.php
+++ b/DependencyInjection/Compiler/PerInstancePass.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 abstract class PerInstancePass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         foreach (self::getSerializers($container) as $scopedContainer) {
             $this->processInstance($scopedContainer);

--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -33,7 +33,7 @@ final class JMSSerializerExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $rawConfigs, ContainerBuilder $container)
+    public function load(array $rawConfigs, ContainerBuilder $container): void
     {
         $configs = $this->processNestedConfigs($rawConfigs, $container);
 

--- a/JMSSerializerBundle.php
+++ b/JMSSerializerBundle.php
@@ -16,6 +16,9 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class JMSSerializerBundle extends Bundle
 {
+    /**
+     * @return void
+     */
     public function build(ContainerBuilder $builder)
     {
         $builder->addCompilerPass(new AssignVisitorsPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

Symfony 6.3 added a number of return types to the framework.  This PR should cover all the ones that popped up when beta testing an application.

Native types are used in all final/internal classes, doc block annotation used otherwise.