### PR TITLE
Don't wire the AttributeDriver

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -113,11 +113,12 @@
             <argument type="service" id="jms_serializer.type_parser" on-invalid="null" />
             <argument type="constant">NULL</argument> <!-- expression evaluator -->
         </service>
-        <service id="jms_serializer.metadata.attribute_driver" class="JMS\Serializer\Metadata\Driver\AttributeDriver" public="false">
+        <!-- TODO - Re-enable this driver at a later time -->
+        <!-- <service id="jms_serializer.metadata.attribute_driver" class="JMS\Serializer\Metadata\Driver\AttributeDriver" public="false">
             <argument type="service" id="jms_serializer.naming_strategy" />
             <argument type="service" id="jms_serializer.type_parser" on-invalid="null" />
-            <argument type="constant">NULL</argument> <!-- expression evaluator -->
-        </service>
+            <argument type="constant">NULL</argument>
+        </service> -->
         <service id="jms_serializer.metadata_driver" class="Metadata\Driver\DriverChain" public="false">
             <argument type="collection">
                 <argument type="constant">NULL</argument> <!-- list of metadata drivers -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #931
| License       | MIT

Fixes the reported issue with a hacky workaround of not wiring in the attribute driver.  I've hit too many brick walls trying to make the annotations/attributes drivers support null returns (decorating drivers expect non-null returns, hierarchical stuff breaks without a metadata object being returned), so until everything can be made to work correctly without these drivers always creating a metadata object, this is the quickest solution.