### PR TITLE
Deprecate the templating component integration

### DIFF
--- a/Templating/SerializerHelper.php
+++ b/Templating/SerializerHelper.php
@@ -13,6 +13,8 @@ use Symfony\Component\Templating\Helper\Helper;
  * Basically provides access to JMSSerializer from PHP templates
  *
  * @author Rafał Wrzeszcz <rafal.wrzeszcz@wrzasq.pl>
+ *
+ * @deprecated use Twig instead
  */
 class SerializerHelper extends Helper
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

In https://github.com/symfony/symfony/pull/51144 the `symfony/templating` component is deprecated for the 6.4 release and removed for 7.0.  This deprecates the integration from this bundle.