### PR TITLE
Add support for Symfony 7, require Symfony 5.4+ and PHP 7.4+

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,8 +17,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.2"
-          - "7.3"
           - "7.4"
           - "8.0"
           - "8.1"
@@ -26,7 +24,7 @@ jobs:
         dependencies:
           - "highest"
         include:
-          - php-version: "7.2"
+          - php-version: "7.4"
             dependencies: "lowest"
 
     steps:

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -10,7 +10,7 @@
     <arg name="colors"/>
     <arg value="nps"/>
 
-    <config name="php_version" value="70200"/>
+    <config name="php_version" value="70400"/>
 
     <file>Cache/</file>
     <file>ContextFactory/</file>

--- a/Cache/CacheWarmer.php
+++ b/Cache/CacheWarmer.php
@@ -38,7 +38,7 @@ class CacheWarmer implements CacheWarmerInterface
      *
      * @return string[] A list of classes or files to preload on PHP 7.4+
      */
-    public function warmUp($cacheDir)
+    public function warmUp(string $cacheDir, ?string $buildDir = null): array
     {
         $finder = Finder::create()
             ->ignoreVCS(true)

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -25,10 +25,7 @@ final class Configuration implements ConfigurationInterface
         $this->debug = $debug;
     }
 
-    /**
-     * @return TreeBuilder
-     */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $tb = new TreeBuilder('jms_serializer');
 

--- a/DependencyInjection/JMSSerializerExtension.php
+++ b/DependencyInjection/JMSSerializerExtension.php
@@ -253,14 +253,10 @@ final class JMSSerializerExtension extends Extension
             $container->removeDefinition('jms_serializer.metadata.doc_block_driver');
         }
 
-        // enable the typed props reader on php 7.4+
-        if (PHP_VERSION_ID >= 70400) {
-            $container->getDefinition('jms_serializer.metadata.typed_properties_driver')
-                ->setDecoratedService('jms_serializer.metadata_driver')
-                ->setPublic(false);
-        } else {
-            $container->removeDefinition('jms_serializer.metadata.typed_properties_driver');
-        }
+        // enable the typed props reader
+        $container->getDefinition('jms_serializer.metadata.typed_properties_driver')
+            ->setDecoratedService('jms_serializer.metadata_driver')
+            ->setPublic(false);
 
         if ($config['enum_support']) {
             $container->getDefinition('jms_serializer.metadata.enum_driver')

--- a/ExpressionLanguage/BasicSerializerFunctionsProvider.php
+++ b/ExpressionLanguage/BasicSerializerFunctionsProvider.php
@@ -12,7 +12,7 @@ class BasicSerializerFunctionsProvider implements ExpressionFunctionProviderInte
     /**
      * @return ExpressionFunction[]
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new ExpressionFunction('service', static function ($arg) {

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -19,7 +19,10 @@ class ConfigurationTest extends TestCase
         $bundles = ['JMSSerializerBundle' => 'JMS\SerializerBundle\JMSSerializerBundle'];
         $container = new ContainerBuilder();
 
-        $container->set('annotation_reader', new AnnotationReader());
+        if (class_exists(AnnotationReader::class)) {
+            $container->set('annotation_reader', new AnnotationReader());
+        }
+
         $container->setParameter('kernel.debug', true);
         $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/serializer');
         $container->setParameter('kernel.bundles', $bundles);

--- a/Tests/DependencyInjection/JMSSerializerExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSerializerExtensionTest.php
@@ -32,7 +32,7 @@ use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
-use Twig\Loader\ContainerRuntimeLoader;
+use Twig\RuntimeLoader\ContainerRuntimeLoader;
 
 class JMSSerializerExtensionTest extends TestCase
 {
@@ -777,10 +777,6 @@ class JMSSerializerExtensionTest extends TestCase
 
     public function testTypedDriverIsEnabled()
     {
-        if (PHP_VERSION_ID < 70400) {
-            $this->markTestSkipped(sprintf('%s requires PHP 7.4', __METHOD__));
-        }
-
         if (!class_exists(TypedPropertiesDriver::class)) {
             $this->markTestSkipped(sprintf('%s requires %s', __METHOD__, TypedPropertiesDriver::class));
         }
@@ -872,7 +868,11 @@ class JMSSerializerExtensionTest extends TestCase
         $container->setParameter('kernel.bundles', []);
         $container->setParameter('kernel.bundles_metadata', []);
         $container->setParameter('foo', 'bar');
-        $container->set('annotation_reader', new AnnotationReader());
+
+        if (class_exists(AnnotationReader::class)) {
+            $container->set('annotation_reader', new AnnotationReader());
+        }
+
         $container->setDefinition('doctrine', new Definition(Registry::class));
 //        $container->setDefinition('doctrine.orm.entity_manager', new Definition(EntityManager::class));
 

--- a/composer.json
+++ b/composer.json
@@ -21,29 +21,30 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "jms/serializer": "^3.28",
         "jms/metadata": "^2.6",
-        "symfony/dependency-injection": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0 || ^6.0"
+        "symfony/config": "^5.4 || ^6.0 || ^7.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
+        "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^8.1",
-        "doctrine/orm": "^2.4",
+        "doctrine/orm": "^2.14",
         "phpunit/phpunit": "^8.0 || ^9.0",
-        "symfony/expression-language": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/finder": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/form": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/stopwatch": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/templating": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/twig-bundle": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/uid": "^5.1 || ^6.0",
-        "symfony/validator": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0"
+        "symfony/expression-language": "^5.4 || ^6.0 || ^7.0",
+        "symfony/finder": "^5.4 || ^6.0 || ^7.0",
+        "symfony/form": "^5.4 || ^6.0 || ^7.0",
+        "symfony/stopwatch": "^5.4 || ^6.0 || ^7.0",
+        "symfony/templating": "^5.4 || ^6.0",
+        "symfony/twig-bundle": "^5.4 || ^6.0 || ^7.0",
+        "symfony/uid": "^5.4 || ^6.0 || ^7.0",
+        "symfony/validator": "^5.4 || ^6.0 || ^7.0",
+        "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
     },
     "suggest": {
-        "symfony/expression-language": "Required for opcache preloading ^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/finder": "Required for cache warmup, supported versions ^3.4 || ^4.0 || ^5.0 || ^6.0"
+        "symfony/expression-language": "Required for opcache preloading ^5.4 || ^6.0 || ^7.0",
+        "symfony/finder": "Required for cache warmup, supported versions ^5.4 || ^6.0 || ^7.0"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | technically yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

Adds Symfony 7 support, WIP as this builds on top of #933 to ensure it works with the annotations support being removed.

Since the first push of this PR failed on the lowest deps build because of incompatible signatures, this will also drop support for Symfony versions before 5.4 (current LTS), and bumps the PHP minimum to 7.4 because according to the [Packagist stats](https://packagist.org/packages/jms/serializer-bundle/php-stats#5) the number of folks running a 5.x release of the bundle on PHP 7.2 or 7.3 is so insignificant that at this point it's just more efficient to drop those EOL PHP branches.