### PR TITLE
Add missing deps on `symfony/config`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "php": "^7.2 || ^8.0",
         "jms/serializer": "^3.20",
         "jms/metadata": "^2.5",
+        "symfony/config": "^3.4 || ^4.0 || ^5.0 || ^6.0",
         "symfony/dependency-injection": "^3.4 || ^4.0 || ^5.0 || ^6.0",
         "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0 || ^6.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | not checked, but as the dependency is already downloaded from another lib, I 99.99% expect "yes"
| Fixed tickets | #941
| License       | MIT

Fixes #941 as long as a new patch is released soon after.

Unecessary if a new JMSSerializerBundle version compatible with Symfony 7 is released earlier.