### PR TITLE
Fix PHP 8.4 deprecation notice

### DIFF
--- a/Debug/DataCollector.php
+++ b/Debug/DataCollector.php
@@ -42,7 +42,7 @@ final class DataCollector extends BaseDataCollector implements LateDataCollector
         $this->reset();
     }
 
-    public function collect(Request $request, Response $response, \Throwable $exception = null): void
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
     }
 


### PR DESCRIPTION
Subj.

See also: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | nope
| License       | MIT

