### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ These guidelines exist not to annoy you, but to keep the code base clean, unifie
 
 ## Coding Standard
 
-This project uses [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) to enforce coding standards.
+This project uses [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) to enforce coding standards.
 The coding standard rules are defined in the **.phpcs.xml.dist** file (part of this repository).
 The project follows a relaxed version of the Doctrine Coding standards v4.
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932